### PR TITLE
add anthropic websearch

### DIFF
--- a/eve/agent/llm.py
+++ b/eve/agent/llm.py
@@ -149,6 +149,14 @@ async def async_anthropic_prompt(
         # cache tools
         tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
 
+        # Add websearch tool:
+        websearch_tool = {
+                "type": "web_search_20250305",
+                "name": "web_search",
+                "max_uses": 2
+        }
+        tool_schemas.append(websearch_tool)
+
         prompt["tools"] = tool_schemas
 
     import time

--- a/eve/agent/llm.py
+++ b/eve/agent/llm.py
@@ -154,9 +154,9 @@ async def async_anthropic_prompt(
         }
         tool_schemas.append(websearch_tool)
         
-        # cache tools (apply to the last tool)
-        if tool_schemas:
-            tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
+        # cache all tools - apply cache_control to each tool for full context caching
+        for tool_schema in tool_schemas:
+            tool_schema["cache_control"] = {"type": "ephemeral"}
 
         prompt["tools"] = tool_schemas
 
@@ -217,9 +217,9 @@ async def async_anthropic_prompt_stream(
         }
         tool_schemas.append(websearch_tool)
         
-        # cache tools (apply to the last tool)
-        if tool_schemas:
-            tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
+        # cache all tools - apply cache_control to each tool for full context caching
+        for tool_schema in tool_schemas:
+            tool_schema["cache_control"] = {"type": "ephemeral"}
             
         prompt["tools"] = tool_schemas
 

--- a/eve/agent/llm.py
+++ b/eve/agent/llm.py
@@ -146,9 +146,6 @@ async def async_anthropic_prompt(
             tool_schemas.append(anthropic_schema)
             prompt["tool_choice"] = {"type": "tool", "name": response_model.__name__}
 
-        # cache tools
-        tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
-
         # Add websearch tool:
         websearch_tool = {
                 "type": "web_search_20250305",
@@ -156,6 +153,10 @@ async def async_anthropic_prompt(
                 "max_uses": 2
         }
         tool_schemas.append(websearch_tool)
+        
+        # cache tools (apply to the last tool)
+        if tool_schemas:
+            tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
 
         prompt["tools"] = tool_schemas
 
@@ -207,6 +208,19 @@ async def async_anthropic_prompt_stream(
         if response_model:
             tool_schemas.append(openai_schema(response_model).anthropic_schema)
             prompt["tool_choice"] = {"type": "tool", "name": response_model.__name__}
+            
+        # Add websearch tool:
+        websearch_tool = {
+                "type": "web_search_20250305",
+                "name": "web_search",
+                "max_uses": 2
+        }
+        tool_schemas.append(websearch_tool)
+        
+        # cache tools (apply to the last tool)
+        if tool_schemas:
+            tool_schemas[-1]["cache_control"] = {"type": "ephemeral"}
+            
         prompt["tools"] = tool_schemas
 
     tool_calls = []

--- a/eve/tool_constants.py
+++ b/eve/tool_constants.py
@@ -70,7 +70,6 @@ BASE_TOOLS = [
     "add_to_collection",
     # misc
     "news",
-    # "websearch",
     "weather",
     # inactive
     # "ominicontrol",


### PR DESCRIPTION
Eve currently still has "websearch" tool, even though its no longer in the `tool_constants.py` I guess this is cause its still in the db so we can manually remove it when this works? Downside is this websearch tool is exclusive to anthropic, so if we ever switch to gemini or gpt, we'd need to patch in another websearch tool.