### PR TITLE
Disable creations3 vector search (eve side)

### DIFF
--- a/eve/api/api_functions.py
+++ b/eve/api/api_functions.py
@@ -477,6 +477,16 @@ async def cleanup_stuck_triggers():
 
 async def embed_recent_creations():
     """Embed recent creations (images & videos) that don't have embeddings yet."""
+    # VECTOR_SEARCH_DISABLED: do not generate new CLIP embeddings.
+    # The creations3.img_vec_idx Atlas Vector Search index was dropped to
+    # free cluster RAM. Without the index, the embeddings have nowhere to
+    # be searched against, so generating them is pure cost (CLIP GPU + disk).
+    # Re-enable by setting VECTOR_SEARCH_ENABLED=true and rebuilding the index.
+    import os as _os
+
+    if _os.getenv("VECTOR_SEARCH_ENABLED") != "true":
+        logger.info("embed_recent_creations skipped (VECTOR_SEARCH_ENABLED!=true)")
+        return
     try:
         import io
         import json

--- a/eve/api/handlers.py
+++ b/eve/api/handlers.py
@@ -1450,6 +1450,13 @@ if os.getenv("MODAL_IS_REMOTE") == "1":
 async def handle_embed(request):
     """Embed images with CLIP"""
 
+    # VECTOR_SEARCH_DISABLED: CLIP text→image embedding feature disabled to
+    # free Atlas Search RAM (creations3.img_vec_idx was 4.92 GB, forced M30).
+    # Re-enable by setting VECTOR_SEARCH_ENABLED=true and rebuilding the
+    # creations3.img_vec_idx Atlas Vector Search index.
+    if os.getenv("VECTOR_SEARCH_ENABLED") != "true":
+        return {"embedding": []}
+
     inputs = proc(
         text=[request.query], return_tensors="pt", padding=True, truncation=True
     ).to(device)
@@ -1463,6 +1470,11 @@ async def handle_embed(request):
 @handle_errors
 async def handle_embedsearch(request):
     """Search images using CLIP embeddings"""
+
+    # VECTOR_SEARCH_DISABLED: see handle_embed above. Returns no results when
+    # disabled rather than 500ing on missing index.
+    if os.getenv("VECTOR_SEARCH_ENABLED") != "true":
+        return {"results": []}
 
     qv_result = await handle_embed(request)
     qv = qv_result["embedding"]

--- a/scripts/disable_creations_vector_search.py
+++ b/scripts/disable_creations_vector_search.py
@@ -1,0 +1,125 @@
+"""
+Disable creations3 vector search to free Atlas Search RAM.
+
+Three steps, run in order:
+  1. Drop the `img_vec_idx` Atlas Vector Search index on creations3
+     (was 4.92 GB on prod, dominating M20's 4 GB RAM budget).
+  2. $unset the `embedding` field from all creations3 documents to reclaim
+     disk + working-set memory. Done in batches.
+  3. Same on eden-stg (smaller index, ~83 MB; included so the schema is
+     consistent across environments).
+
+Pre-req: code in eve and eden1 has the VECTOR_SEARCH_DISABLED guards in
+place (otherwise dropping the index will start producing 500s for
+in-flight $vectorSearch queries).
+
+Run with a writable Mongo URI (atlasAdmin or equivalent).
+
+To restore the feature later:
+  - Re-create the Atlas Vector Search index in the Atlas UI:
+      db: eden-prod, collection: creations3, name: img_vec_idx,
+      type: vectorSearch, definition matching the original.
+  - Set env VECTOR_SEARCH_ENABLED=true on the API and Modal services.
+  - Run the embed_recent_creations cron to backfill embeddings.
+"""
+
+import os
+import sys
+import time
+
+from pymongo import MongoClient
+from pymongo.errors import OperationFailure
+
+TARGETS = [
+    ("eden-prod", "creations3", "img_vec_idx"),
+    ("eden-stg", "creations3", "img_vec_idx"),
+]
+
+UNSET_BATCH_SIZE = 1000
+
+
+def drop_search_index(
+    client: MongoClient, db_name: str, coll_name: str, idx_name: str
+) -> None:
+    coll = client[db_name][coll_name]
+    try:
+        existing = list(coll.aggregate([{"$listSearchIndexes": {}}]))
+    except OperationFailure as e:
+        print(f"  ✗ {db_name}.{coll_name}: cannot list search indexes ({e}); skipping")
+        return
+
+    matching = [i for i in existing if i.get("name") == idx_name]
+    if not matching:
+        print(
+            f"  ⊙ {db_name}.{coll_name}: search index '{idx_name}' not found (already dropped?)"
+        )
+        return
+
+    print(
+        f"  → {db_name}.{coll_name}: dropping search index '{idx_name}' "
+        f"(type={matching[0].get('type','?')}, status={matching[0].get('status','?')}) ..."
+    )
+    coll.drop_search_index(idx_name)
+    print(
+        f"  ✓ {db_name}.{coll_name}: drop_search_index('{idx_name}') accepted (async)"
+    )
+
+
+def unset_embeddings(client: MongoClient, db_name: str, coll_name: str) -> None:
+    coll = client[db_name][coll_name]
+    total = coll.count_documents({"embedding": {"$exists": True}})
+    if total == 0:
+        print(f"  ⊙ {db_name}.{coll_name}: no documents with embedding field")
+        return
+
+    print(
+        f"  → {db_name}.{coll_name}: {total:,} docs have an `embedding` field; "
+        f"unsetting in batches of {UNSET_BATCH_SIZE} ..."
+    )
+    done = 0
+    t0 = time.time()
+    while True:
+        ids = [
+            d["_id"]
+            for d in coll.find({"embedding": {"$exists": True}}, {"_id": 1}).limit(
+                UNSET_BATCH_SIZE
+            )
+        ]
+        if not ids:
+            break
+        result = coll.update_many({"_id": {"$in": ids}}, {"$unset": {"embedding": ""}})
+        done += result.modified_count
+        elapsed = time.time() - t0
+        rate = done / elapsed if elapsed > 0 else 0
+        print(f"     {done:,}/{total:,}  ({rate:.0f}/s)")
+    print(f"  ✓ {db_name}.{coll_name}: unset complete in {time.time()-t0:.1f}s")
+
+
+def main() -> int:
+    uri = os.environ.get("MONGO_URI")
+    if not uri:
+        print("ERROR: MONGO_URI not set", file=sys.stderr)
+        return 1
+
+    do_drop = os.environ.get("DROP_INDEX", "true").lower() == "true"
+    do_unset = os.environ.get("UNSET_EMBEDDING", "true").lower() == "true"
+
+    client = MongoClient(uri, serverSelectionTimeoutMS=10000, retryWrites=True)
+    client.admin.command("ping")
+
+    if do_drop:
+        print("\n=== Step 1: drop Atlas Vector Search index ===")
+        for db_name, coll_name, idx_name in TARGETS:
+            drop_search_index(client, db_name, coll_name, idx_name)
+
+    if do_unset:
+        print("\n=== Step 2: $unset `embedding` field from all docs ===")
+        for db_name, coll_name, _ in TARGETS:
+            unset_embeddings(client, db_name, coll_name)
+
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- The eden1-side disable for creations3 \`\$vectorSearch\` shipped in https://github.com/edenartlab/eden#a56bcd62f.
- This is the matching eve side (commit \`17190657\`, didn't make it into the original PR #540 because it was pushed after that PR was merged).
- Gates \`/embed\` and \`/embedsearch\` route handlers behind \`VECTOR_SEARCH_ENABLED=true\` env (default off).
- **Most importantly: gates the \`embed_recent_creations\` Modal cron** which currently runs every 5 minutes in prod, generating new CLIP embeddings on every recent creation. Without this commit, the cron will keep regenerating embeddings even after the index is dropped.
- Adds \`scripts/disable_creations_vector_search.py\` for the one-off index drop + embedding-field cleanup.

## Test plan
- [ ] Merge → staging → main, redeploy
- [ ] Verify \`embed_recent_creations\` Modal logs show \"skipped (VECTOR_SEARCH_ENABLED!=true)\" on next 5-minute fire
- [x] Cleanup script will be run separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)