### PR TITLE
Modal cost cuts + LLM safety (deployed 2026-07-09)

### DIFF
--- a/eve/agent/llm/llm.py
+++ b/eve/agent/llm/llm.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple
 
+import sentry_sdk
+
 from eve.agent.llm.constants import MODEL_PROVIDER_OVERRIDES, ModelProvider
 from eve.agent.llm.providers import LLMProvider
 from eve.agent.llm.token_tracker import token_tracker
@@ -40,6 +42,16 @@ class FallbackChainProvider(LLMProvider):
                 logger.warning(
                     f"Provider {provider.__class__.__name__} failed, trying next: {exc}"
                 )
+                # Fallover must be LOUD: silently shifting traffic to the next
+                # provider changes cost/behavior (e.g. haiku -> gpt-5.4).
+                try:
+                    sentry_sdk.capture_message(
+                        f"LLM provider fallover: {provider.__class__.__name__} failed, "
+                        f"falling back. Error: {exc}",
+                        level="warning",
+                    )
+                except Exception:
+                    pass
                 last_error = exc
         if last_error:
             raise last_error
@@ -56,6 +68,14 @@ class FallbackChainProvider(LLMProvider):
                 logger.warning(
                     f"Provider {provider.__class__.__name__} failed (stream), trying next: {exc}"
                 )
+                try:
+                    sentry_sdk.capture_message(
+                        f"LLM provider fallover (stream): {provider.__class__.__name__} "
+                        f"failed, falling back. Error: {exc}",
+                        level="warning",
+                    )
+                except Exception:
+                    pass
                 last_error = exc
         if last_error:
             raise last_error
@@ -228,6 +248,7 @@ def _extract_system_message(messages: List[ChatMessage]) -> str:
     """Extract concatenated system message from messages list."""
     system_parts = [m.content for m in messages if m.role == "system" and m.content]
     return "\n\n".join(system_parts)
+
 
 async def async_prompt(
     context: LLMContext,

--- a/eve/agent/session/runtime.py
+++ b/eve/agent/session/runtime.py
@@ -235,7 +235,19 @@ class PromptSessionRuntime:
                     self.rate_limiter = RateLimiter()
 
             prompt_session_finished = False
+            # Hard backstop: the loop otherwise only exits on LLM stop-reason,
+            # and the manna/rate-limit guards are feature-flagged. Without this,
+            # an always-erroring tool can burn tokens until the Modal timeout.
+            max_turns = int(os.getenv("MAX_PROMPT_SESSION_TURNS", "25"))
+            turn_count = 0
             while not prompt_session_finished:
+                turn_count += 1
+                if turn_count > max_turns:
+                    logger.error(
+                        f"Prompt session exceeded {max_turns} turns; force-stopping "
+                        f"(session={getattr(self.session, 'id', None)})"
+                    )
+                    break
                 self._ensure_not_cancelled()
                 await self._refresh_llm_messages()
                 self._maybe_disable_tools()

--- a/eve/api/api.py
+++ b/eve/api/api.py
@@ -715,7 +715,7 @@ run_3h = app.function(
 
 run_task = app.function(
     image=image,
-    min_containers=2,
+    min_containers=0,  # cost: cold-start OK on wind-down (was 2 warm 24/7)
     max_containers=10,
     timeout=3600,
     volumes={
@@ -727,7 +727,7 @@ run_task = app.function(
 
 run_task_replicate = app.function(
     image=image,
-    min_containers=2,
+    min_containers=0,  # cost: cold-start OK (was 2 warm 24/7)
     max_containers=10,
     timeout=3600,
     volumes={
@@ -738,7 +738,7 @@ run_task_replicate = app.function(
 
 
 cleanup_stale_busy_states_modal = app.function(
-    image=image, max_containers=1, schedule=modal.Period(minutes=2), timeout=3600
+    image=image, max_containers=1, schedule=modal.Period(minutes=10), timeout=3600
 )(cleanup_stale_busy_states)
 
 
@@ -775,7 +775,7 @@ memory2_process_cold_sessions = app.function(
 
 create_concept_thumbnail = app.function(
     image=image,
-    min_containers=1,
+    min_containers=0,  # cost: cold-start OK (was 1 warm 24/7)
     max_containers=10,
     timeout=600,
     volumes={"/data/media-cache": media_cache_vol},
@@ -798,7 +798,7 @@ async def execute_trigger_fn(
 
 
 @app.function(
-    image=image, max_containers=1, schedule=modal.Period(minutes=2), timeout=300
+    image=image, max_containers=1, schedule=modal.Period(minutes=5), timeout=300
 )
 async def run_scheduled_triggers_fn():
     current_time = datetime.now(timezone.utc)
@@ -909,7 +909,7 @@ async def process_twitter_tweet_fn(
 @app.function(
     image=image,
     max_containers=1,
-    schedule=modal.Period(minutes=1),
+    schedule=modal.Period(minutes=15),
     timeout=600,
 )
 async def poll_twitter_gateway_fn():

--- a/eve/mongo.py
+++ b/eve/mongo.py
@@ -25,7 +25,7 @@ def get_mongo_client():
         _mongo_client = MongoClient(
             MONGO_URI,
             maxPoolSize=50,
-            minPoolSize=10,
+            minPoolSize=0,  # was 10: every warm container held >=10 idle Atlas connections
             maxIdleTimeMS=60000,
             connectTimeoutMS=5000,
             serverSelectionTimeoutMS=3000,

--- a/eve/tool_constants.py
+++ b/eve/tool_constants.py
@@ -48,6 +48,9 @@ BASE_MODELS = Literal[
     "svd-xt",
     "ltxv",
     "nano-banana",
+    "wan21",
+    "sd35",
+    "hellomeme",
 ]
 
 # These tools are default agent tools except Eve


### PR DESCRIPTION
Modal cost + safety changes from the 2026-07-09 audit. **Already deployed to Modal PROD+STAGE from the working tree — merge this to persist across CI redeploys** (otherwise the next push to main/staging reverts the warm-container cuts).

## Cost (deployed)
- `min_containers` 2/2/1 -> **0** on `run_task`, `run_task_replicate`, `create_concept_thumbnail` (were 5 always-warm CPU containers 24/7).
- Throttle timer crons: `poll_twitter` 1->15min, `cleanup_stale_busy` 2->10min, `run_scheduled_triggers` 2->5min.
- mongo `minPoolSize` 10 -> 0 (each warm container held >=10 idle Atlas connections).

Also done outside this diff: Modal plan Team->Starter (-$180/mo); `discord-gateway-v2` PROD+STAGE stopped (14 v2 bots retired per owner).

## Bug / safety
- `BASE_MODELS` += `wan21`/`sd35`/`hellomeme` — these workflow tools were failing Pydantic validation and being **silently dropped** on load (the `base_model='wan21'` 500).
- `FallbackChainProvider`: `sentry_sdk.capture_message` on every provider fallover — was **silent**, so a revoked Anthropic key invisibly shifted 100% of traffic (and cost) to gpt-5.4.
- `runtime.py`: hard `max_turns` cap (env `MAX_PROMPT_SESSION_TURNS`, default 25) on the agent loop — the manna/rate-limit backstops are feature-flagged off, so an always-erroring tool could loop until the Modal timeout burning tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)