### PR TITLE
ci: bump modal 1.1.0 -> 1.5.2 (fix input-plane deploy failure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "motor>=3.6.0",
     "beanie==1.22.6",
     "apscheduler>=3.11.0",
-    "modal>=1.0.1",
+    "modal>=1.1.3",
     "pytz>=2025.2",
     "fal-client==0.5.9",
     "torch==2.7.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -46,7 +46,6 @@ attrs==25.3.0
     # via igittigitt
     # via jsonschema
     # via referencing
-    # via sigtools
 awacs==2.5.0
     # via runway
 aws-sam-translator==1.100.0
@@ -77,6 +76,8 @@ bracex==2.6
     # via wcmatch
 canonicaljson==2.0.0
     # via farcaster
+cbor2==6.1.3
+    # via modal
 certifi==2025.7.14
     # via httpcore
     # via httpx
@@ -412,7 +413,7 @@ mkdocs-material==9.6.18
     # via instructor
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-modal==1.1.0
+modal==1.5.2
     # via eve
 motor==3.7.1
     # via beanie
@@ -718,8 +719,6 @@ shapely==2.1.1
     # via google-cloud-aiplatform
 shellingham==1.5.4
     # via typer
-sigtools==4.0.1
-    # via synchronicity
 six==1.17.0
     # via cfn-flip
     # via posthog
@@ -741,7 +740,7 @@ starlette==0.47.2
 sympy==1.14.0
     # via cfn-lint
     # via torch
-synchronicity==0.10.1
+synchronicity==0.12.5
     # via modal
 tenacity==9.1.2
     # via eve
@@ -777,7 +776,6 @@ tweepy==4.16.0
     # via eve
 typer==0.16.0
     # via instructor
-    # via modal
 types-certifi==2021.10.8.3
     # via modal
 types-requests==2.32.4.20250611

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,7 +46,6 @@ attrs==25.3.0
     # via igittigitt
     # via jsonschema
     # via referencing
-    # via sigtools
 awacs==2.5.0
     # via runway
 aws-sam-translator==1.100.0
@@ -77,6 +76,8 @@ bracex==2.6
     # via wcmatch
 canonicaljson==2.0.0
     # via farcaster
+cbor2==6.1.3
+    # via modal
 certifi==2025.7.14
     # via httpcore
     # via httpx
@@ -410,7 +411,7 @@ mkdocs-material==9.6.18
     # via instructor
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-modal==1.1.0
+modal==1.5.2
     # via eve
 motor==3.7.1
     # via beanie
@@ -702,8 +703,6 @@ shapely==2.1.1
     # via google-cloud-aiplatform
 shellingham==1.5.4
     # via typer
-sigtools==4.0.1
-    # via synchronicity
 six==1.17.0
     # via cfn-flip
     # via posthog
@@ -725,7 +724,7 @@ starlette==0.47.2
 sympy==1.14.0
     # via cfn-lint
     # via torch
-synchronicity==0.10.1
+synchronicity==0.12.5
     # via modal
 tenacity==9.1.2
     # via eve
@@ -761,7 +760,6 @@ tweepy==4.16.0
     # via eve
 typer==0.16.0
     # via instructor
-    # via modal
 types-certifi==2021.10.8.3
     # via modal
 types-requests==2.32.4.20250611


### PR DESCRIPTION
## Problem
CI `Deploy to Modal Production/Staging` has been failing since ~2026-07-13: `rye sync` installs `modal==1.1.0` (pinned in `requirements.lock`), and Modal's input-plane rollout now rejects it:
```
Input plane is not supported for client_version='1.1.0'. Please upgrade to 1.1.3 or later.
```
api-prod + api-stage had to be deployed manually with a newer local client (1.4.2) to ship the merged #549 fixes.

## Fix
- `pyproject.toml`: `modal>=1.0.1` → `modal>=1.1.3`
- `rye lock --update modal` → `modal==1.5.2` (+ deps: synchronicity 0.10.1→0.12.5, +cbor2, −sigtools)

Diff is limited to modal + its transitive deps. Restores automatic CI deploys.