### PR TITLE
cost: api-stage web app cold-starts (min_containers=0 on STAGE)

### DIFF
--- a/eve/api/api.py
+++ b/eve/api/api.py
@@ -620,7 +620,7 @@ image = (
 
 @app.function(
     image=image,
-    min_containers=1,
+    min_containers=1 if db == "PROD" else 0,  # STAGE cold-starts (cost)
     max_containers=10,
     scaledown_window=60,
     timeout=3600 * 3,  # 3 hours


### PR DESCRIPTION
The fastapi web function hardcodes `min_containers=1`, keeping a warm api-stage container 24/7 (~$11/mo). Runtime autoscaler fixes get reverted on every CI redeploy. Gate on `db` (PROD warm, STAGE cold-start) so it's durable. STAGE = low-traffic staging, cold start is fine.