### PR TITLE
cost: stop deploying discord gateway to STAGE

### DIFF
--- a/.github/workflows/deploy-gateway3.yaml
+++ b/.github/workflows/deploy-gateway3.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
 
 jobs:
   deploy-gateway:


### PR DESCRIPTION
`deploy-gateway3.yaml` triggered on `staging` pushes, re-creating an always-on `discord-gateway-v3-STAGE` container (~$13/mo) each time — it kept coming back after being stopped. Remove the `staging` trigger; PROD gateway still deploys on `main`. **Does not touch** api-stage (staging.yaml) or staging.app.eden.art (docker on the box).