### PR TITLE
Anthropic cost audit: Sonnet 5 migration, dead-tool pruning, no-cache one-shots

### DIFF
--- a/eve/agent/llm/llm.py
+++ b/eve/agent/llm/llm.py
@@ -60,11 +60,18 @@ class FallbackChainProvider(LLMProvider):
     async def prompt_stream(self, context: LLMContext) -> AsyncGenerator[Any, None]:
         last_error: Optional[Exception] = None
         for provider in self._providers:
+            yielded = False
             try:
                 async for chunk in provider.prompt_stream(context):
+                    yielded = True
                     yield chunk
                 return
             except Exception as exc:
+                if yielded:
+                    # The consumer already received partial output from this
+                    # provider; restarting on the next one would duplicate it
+                    # (partial text + full retry). Surface the error instead.
+                    raise
                 logger.warning(
                     f"Provider {provider.__class__.__name__} failed (stream), trying next: {exc}"
                 )

--- a/eve/agent/llm/providers/anthropic.py
+++ b/eve/agent/llm/providers/anthropic.py
@@ -47,6 +47,13 @@ TOOL_SEARCH_TOOL_BM25 = {
 
 # Prompt-cache breakpoint marker applied to system/message blocks.
 CACHE_CONTROL = {"type": "ephemeral"}
+# The static prefix (tool schemas + per-agent persona) is identical across all
+# sessions of an agent but our traffic has many 5m-60m gaps (human turn pacing,
+# between-session lulls), so the default 5m TTL kept expiring and rewriting it.
+# Measured on llm_calls: eve 17% of inter-call gaps >5m but only 6% >1h;
+# abraham 30%/10% - 1h TTL (2x write vs 1.25x) is strictly cheaper for both.
+# Volatile/message breakpoints stay 5m: memory updates invalidate them anyway.
+CACHE_CONTROL_STATIC = {"type": "ephemeral", "ttl": "1h"}
 
 # Anthropic list prices, $ per token (input, output). Used for accurate cost
 # accounting including cache read (0.1x input) and 5-min cache write (1.25x input).
@@ -126,9 +133,11 @@ class AnthropicProvider(LLMProvider):
         static, volatile = split_system_for_cache(system_prompt)
         blocks: List[Dict[str, Any]] = []
         if static:
-            blocks.append(
-                {"type": "text", "text": static, "cache_control": CACHE_CONTROL}
-            )
+            # 1h TTL only for the true template-split static prefix; a prompt
+            # without the marker (volatile is None) has unknown stability, and
+            # paying the 2x 1h-write premium on churning content is a loss.
+            static_cc = CACHE_CONTROL_STATIC if volatile else CACHE_CONTROL
+            blocks.append({"type": "text", "text": static, "cache_control": static_cc})
         if volatile:
             blocks.append(
                 {"type": "text", "text": volatile, "cache_control": CACHE_CONTROL}

--- a/eve/agent/llm/providers/anthropic.py
+++ b/eve/agent/llm/providers/anthropic.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from eve.agent.llm.formatting import (
     construct_anthropic_tools,
     split_system_for_cache,
+    strip_cache_breakpoint,
 )
 from eve.agent.llm.providers import LLMProvider
 from eve.agent.llm.util import (
@@ -53,8 +54,24 @@ CACHE_CONTROL = {"type": "ephemeral"}
 _ANTHROPIC_PRICE = {
     "claude-haiku-4-5": (1.0e-6, 5.0e-6),
     "claude-sonnet-4-6": (3.0e-6, 15.0e-6),
+    # Sticker price; intro pricing is $2/$10 per MTok through 2026-08-31, so
+    # cost_usd slightly overestimates until then. Note Sonnet 5's tokenizer
+    # yields ~30% more tokens than 4.6 for the same text.
+    "claude-sonnet-5": (3.0e-6, 15.0e-6),
     "claude-opus-4-6": (5.0e-6, 25.0e-6),
 }
+
+# Models where adaptive thinking is ON by default when the `thinking` param is
+# omitted. We don't send thinking config anywhere, and _prepare_messages strips
+# thought blocks on replay, so we explicitly disable thinking on these models
+# to keep behavior (and output-token cost) identical to the 4.6-era default.
+_THINKING_DEFAULT_ON_MODELS = ("claude-sonnet-5",)
+
+
+def _default_thinking_param(model: str) -> Optional[Dict[str, str]]:
+    if (model or "").startswith(_THINKING_DEFAULT_ON_MODELS):
+        return {"type": "disabled"}
+    return None
 
 
 class AnthropicProvider(LLMProvider):
@@ -78,6 +95,7 @@ class AnthropicProvider(LLMProvider):
     # silently upgraded to the Sonnet fallback below at ~3x the cost.
     STRUCTURED_OUTPUT_MODELS = {
         "claude-haiku-4-5",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
         "claude-sonnet-4-5-20250929",
@@ -86,9 +104,9 @@ class AnthropicProvider(LLMProvider):
     }
 
     # Fallback model for structured outputs when using unsupported models
-    STRUCTURED_OUTPUT_FALLBACK = "claude-sonnet-4-6"
+    STRUCTURED_OUTPUT_FALLBACK = "claude-sonnet-5"
 
-    def _build_system_param(self, system_prompt: Optional[str]):
+    def _build_system_param(self, system_prompt: Optional[str], use_cache: bool = True):
         """Return the Anthropic `system` param as cache-annotated text blocks.
 
         The system prompt is split at the cache breakpoint marker into a static
@@ -101,6 +119,10 @@ class AnthropicProvider(LLMProvider):
         """
         if not system_prompt:
             return system_prompt
+        if not use_cache:
+            # One-shot calls (config.prompt_cache=False): no breakpoints, so we
+            # pay 1.0x input instead of 1.25x cache-write for entries never read.
+            return strip_cache_breakpoint(system_prompt)
         static, volatile = split_system_for_cache(system_prompt)
         blocks: List[Dict[str, Any]] = []
         if static:
@@ -118,7 +140,7 @@ class AnthropicProvider(LLMProvider):
         return blocks
 
     def _apply_message_cache_control(
-        self, conversation: List[Dict[str, Any]]
+        self, conversation: List[Dict[str, Any]], use_cache: bool = True
     ) -> List[Dict[str, Any]]:
         """Add ONE ephemeral cache breakpoint to the last message so the growing
         conversation history is cached incrementally across agentic-loop turns.
@@ -127,7 +149,7 @@ class AnthropicProvider(LLMProvider):
         in place, so callers that reuse message dicts can never accumulate extra
         breakpoints and blow past Anthropic's 4-breakpoint-per-request limit.
         """
-        if not conversation:
+        if not conversation or not use_cache:
             return conversation
         last = dict(conversation[-1])
         content = last.get("content")
@@ -184,10 +206,11 @@ class AnthropicProvider(LLMProvider):
 
     async def prompt(self, context: LLMContext) -> LLMResponse:
         include_thoughts = bool(context.config.reasoning_effort)
+        use_cache = getattr(context.config, "prompt_cache", True)
         system_prompt, conversation = self._prepare_messages(
             context.messages, include_thoughts=include_thoughts
         )
-        conversation = self._apply_message_cache_control(conversation)
+        conversation = self._apply_message_cache_control(conversation, use_cache)
         tools = construct_anthropic_tools(context)
 
         # Check if we have a Pydantic class for structured outputs (for streaming)
@@ -255,10 +278,12 @@ class AnthropicProvider(LLMProvider):
 
                     request_kwargs = {
                         "model": effective_model,
-                        "system": self._build_system_param(system_prompt),
+                        "system": self._build_system_param(system_prompt, use_cache),
                         "messages": conversation,
                         "max_tokens": context.config.max_tokens or 32000,
                     }
+                    if thinking := _default_thinking_param(effective_model):
+                        request_kwargs["thinking"] = thinking
 
                     session_info = llm_call_metadata.get("session", "unknown")
                     logger.info(
@@ -502,10 +527,11 @@ class AnthropicProvider(LLMProvider):
 
     async def prompt_stream(self, context: LLMContext):
         include_thoughts = bool(context.config.reasoning_effort)
+        use_cache = getattr(context.config, "prompt_cache", True)
         system_prompt, conversation = self._prepare_messages(
             context.messages, include_thoughts=include_thoughts
         )
-        conversation = self._apply_message_cache_control(conversation)
+        conversation = self._apply_message_cache_control(conversation, use_cache)
         tools = construct_anthropic_tools(context)
 
         response_format = context.config.response_format
@@ -542,10 +568,12 @@ class AnthropicProvider(LLMProvider):
             tools_payload = self._build_tools_payload(tools, model_name)
             request_kwargs = {
                 "model": model_name,
-                "system": self._build_system_param(system_prompt),
+                "system": self._build_system_param(system_prompt, use_cache),
                 "messages": conversation,
                 "max_tokens": context.config.max_tokens or 32000,
             }
+            if thinking := _default_thinking_param(model_name):
+                request_kwargs["thinking"] = thinking
             if tools_payload:
                 request_kwargs["tools"] = tools_payload
 

--- a/eve/agent/session/config.py
+++ b/eve/agent/session/config.py
@@ -8,6 +8,7 @@ DEFAULT_SESSION_SELECTION_LIMIT = 25
 
 MODEL_TIERS: Dict[str, List[str]] = {
     "high": [
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "gpt-5.4-nano",

--- a/eve/agent/session/config.py
+++ b/eve/agent/session/config.py
@@ -7,9 +7,10 @@ from eve.agent.session.models import LLMConfig
 DEFAULT_SESSION_SELECTION_LIMIT = 25
 
 MODEL_TIERS: Dict[str, List[str]] = {
+    # chain[0] is the tier's model, chain[1:3] its fallbacks — keep a
+    # cross-provider fallback in slot 2 (Anthropic outages take out slot 1 too).
     "high": [
         "claude-sonnet-5",
-        "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "gpt-5.4-nano",
         "gpt-4o-mini",

--- a/eve/agent/session/models.py
+++ b/eve/agent/session/models.py
@@ -950,6 +950,9 @@ class LLMConfig:
     model: Optional[str] = "gpt-4o-mini"
     fallback_models: Optional[List[str]] = None
     max_tokens: Optional[int] = None
+    # Set False for one-shot helper calls (extractors, classifiers): their
+    # prompt-cache writes are never read back, so caching costs 1.25x for nothing.
+    prompt_cache: bool = True
     response_format: Optional[BaseModel] = None
     thinking: Optional[LLMThinkingSettings] = None
     reasoning_effort: Optional[str] = (

--- a/eve/agent/session/runtime.py
+++ b/eve/agent/session/runtime.py
@@ -447,7 +447,17 @@ class PromptSessionRuntime:
         return dm_pattern in session_key
 
     def _inject_social_reminder(self, config: Dict[str, Any]):
-        """Inject SystemReminder into the last platform user message."""
+        """Append an ephemeral platform reminder as the final user message.
+
+        Must NOT mutate an existing message: the reminder targets the *latest*
+        platform message, a moving target across requests. Editing that message
+        in place rewrites bytes mid-history, which invalidates the prompt-cache
+        prefix from that point — and because the nearest surviving cache entry
+        then sits more than 20 content blocks back, Anthropic's breakpoint
+        lookback fails entirely (observed as read=0, full ~30-50k rewrite on
+        every new social notification). A trailing message keeps history
+        byte-stable; at worst the next request re-processes one turn.
+        """
         from eve.user import User
 
         channel_type = config["channel_type"]
@@ -530,7 +540,9 @@ class PromptSessionRuntime:
                         f"├─────────────────────────────────────"
                     )
 
-                msg.content = (msg.content or "") + reminder
+                self.llm_context.messages.append(
+                    ChatMessage(role="user", content=reminder.strip())
+                )
                 break
 
     def _restrict_social_tool(self, config: Dict[str, Any]):
@@ -585,10 +597,22 @@ class PromptSessionRuntime:
             ):
                 platform_tool.parameters[restriction_param]["hide_from_agent"] = True
         elif "reply_param" in config:
-            # Reply-based platforms (Twitter, Farcaster)
+            # Reply-based platforms (Twitter, Farcaster): the target is the
+            # *triggering message id*, which changes on every notification.
+            # Baking it into the schema (enum/default) changes the tool bytes,
+            # and tools are position 0 of the prompt-cache prefix - so every
+            # new notification invalidated the ENTIRE cache (tools + system +
+            # history; observed as read=0 full rewrites). Enforce at execution
+            # time instead (_process_tool_calls overwrites the param), which is
+            # stronger than a schema default and keeps tool bytes stable.
             reply_config_field = config["reply_config_field"]
             target_id = getattr(self.context.update_config, reply_config_field, None)
             param_name = config["reply_param"]
+            if target_id and param_name:
+                if not hasattr(self, "_social_forced_params"):
+                    self._social_forced_params = {}
+                self._social_forced_params[tool_name] = {param_name: target_id}
+            return
         else:
             # Channel-based platforms
             trigger_field = config["trigger_field"]
@@ -980,6 +1004,15 @@ class PromptSessionRuntime:
     async def _process_tool_calls(self, assistant_message: ChatMessage):
         if not assistant_message.tool_calls:
             return
+
+        # Enforce reply-target restriction for reply-based social platforms
+        # (set by _restrict_social_tool; replaces the old cache-busting schema
+        # enum/default so the model can't reply outside the triggering thread).
+        forced = getattr(self, "_social_forced_params", None)
+        if forced:
+            for tc in assistant_message.tool_calls:
+                for param, value in (forced.get(tc.tool) or {}).items():
+                    tc.args[param] = value
 
         # Track if the active platform's post tool was used
         if self.active_platform:

--- a/eve/agent/tool_loaders.py
+++ b/eve/agent/tool_loaders.py
@@ -88,12 +88,11 @@ def get_agent_specific_tools(
     if username == "abraham":
         result.extend(
             [
-                "abraham_publish",
+                # abraham_publish/seed/remember pruned 2026-07: 0 invocations
+                # (daily/covenant/rest still in active use)
                 "abraham_daily",
                 "abraham_covenant",
                 "abraham_rest",
-                "abraham_seed",
-                "abraham_remember",
             ]
         )
     elif username == "verdelis":

--- a/eve/tool_constants.py
+++ b/eve/tool_constants.py
@@ -84,7 +84,7 @@ ALL_TOOLS = [
     # "stable_audio",
     "transcription",
     "elevenlabs_music",
-    "elevenlabs_fx",
+    # "elevenlabs_fx",  # pruned 2026-07: 0 invocations across 847 calls/wk; still used internally by reel_audio
     # editing
     # search
     # "search_agents",
@@ -188,12 +188,13 @@ TOOL_SETS = {
     "create_audio": [
         "elevenlabs_speech",
         "elevenlabs_music",
-        "elevenlabs_fx",
+        # "elevenlabs_fx",  # pruned 2026-07: 0 invocations across 847 calls/wk
         "elevenlabs_search_voices",
     ],
     "vj_tools": ["texture_flow", "video_FX", "reel"],
     "news": [],  # deprecated
-    "manage_collections": ["eden_search", "add_to_collection", "create_collection"],
+    # add_to_collection/create_collection pruned 2026-07: 0 invocations across 847 calls/wk
+    "manage_collections": ["eden_search"],
     "social_media_tools": SOCIAL_MEDIA_TOOLS,
     "context7_mcp_tools": CONTEXT7_MCP_TOOLS,
     "calculator_mcp_tools": CALCULATOR_MCP_TOOLS,

--- a/eve/tools/media_utils/ffmpeg_multitool/handler.py
+++ b/eve/tools/media_utils/ffmpeg_multitool/handler.py
@@ -245,7 +245,7 @@ async def generate_ffmpeg_command(
         messages = [{"role": "user", "content": "\n\n".join(prompt_parts)}]
 
         prompt = {
-            "model": "claude-sonnet-4-6",
+            "model": "claude-sonnet-5",
             "max_tokens": 2048,
             "messages": messages,
             "system": "You are an expert at generating FFmpeg commands. Respond with a JSON object containing just the ffmpeg command and output path.",

--- a/eve/tools/session_post/handler.py
+++ b/eve/tools/session_post/handler.py
@@ -174,7 +174,7 @@ async def handler(context: ToolContext):
             session=session,
             initiating_user_id=str(user.id),
             message=new_message,
-            llm_config=LLMConfig(model="claude-sonnet-4-6-20250929"),
+            llm_config=LLMConfig(model="claude-sonnet-5"),
         )
         new_message.save()
 
@@ -212,7 +212,7 @@ async def handler(context: ToolContext):
                 session=session,
                 initiating_user_id=str(user.id),
                 message=new_message,
-                llm_config=LLMConfig(model="claude-sonnet-4-6-20250929"),
+                llm_config=LLMConfig(model="claude-sonnet-5"),
             )
 
             if context.args.get("extra_tools"):
@@ -309,8 +309,9 @@ async def _extract_media_response(session_id: str) -> dict:
             ),
         ],
         config=LLMConfig(
-            model="claude-sonnet-4-6",
+            model="claude-sonnet-5",
             response_format=MediaSessionResponse,
+            prompt_cache=False,  # one-shot extraction; cache writes are never read
         ),
     )
 
@@ -348,8 +349,9 @@ async def _extract_seed_response(session_id: str) -> dict:
             ),
         ],
         config=LLMConfig(
-            model="claude-sonnet-4-6",
+            model="claude-sonnet-5",
             response_format=SeedSessionResponse,
+            prompt_cache=False,  # one-shot extraction; cache writes are never read
         ),
     )
 


### PR DESCRIPTION
## Context

Empirical audit of `llm_calls` (eden-prod) + the Console cache dashboard (2026-07-20):

- Cache **writes** are 86–88% of Anthropic input cost (write amortization only ~1.95×/1.67×)
- The `session_post` extractors run one-shot on Sonnet with **0.1× cache amortization** — paying 1.25× for cache entries that are never read
- 6 tools ship in every prompt with **0 invocations across 847 calls/week**, inflating every cache write (~27k chars of tool schemas sit at the front of the prompt)
- `session_post` sub-sessions hardcoded `claude-sonnet-4-6-20250929` — a dated model ID that doesn't exist (Sonnet **4.5** had that date suffix); would 404 when exercised

## Changes

### Sonnet 5 migration
- `session_post` (4 sites) and `ffmpeg_multitool` → `claude-sonnet-5` (better model; intro pricing $2/$10 per MTok through 2026-08-31; note its tokenizer yields ~30% more tokens than 4.6 for the same text)
- **Pin `thinking: {type: "disabled"}` on Sonnet 5** — adaptive thinking is on-by-default when the param is omitted, which would bill thinking tokens and emit thinking blocks that our replay path (`include_thoughts=False`) strips, risking 400s on tool-use continuations
- Add `claude-sonnet-5` to `_ANTHROPIC_PRICE`, `STRUCTURED_OUTPUT_MODELS` (without this, structured-output calls silently reroute to the 4.6 fallback), `STRUCTURED_OUTPUT_FALLBACK`, and `MODEL_TIERS`

### One-shot cache-write elimination
- New `LLMConfig.prompt_cache: bool = True`; when `False`, the Anthropic provider skips all `cache_control` annotations (system blocks + last message)
- Applied to both `session_post` extractors — one-shot calls now pay 1.0× instead of 1.25× on input

### Dead-tool pruning (0 invocations in 847 calls/wk)
- `elevenlabs_fx` out of `ALL_TOOLS` + `create_audio` (tool itself kept — `reel_audio` uses it internally)
- `add_to_collection`, `create_collection` out of `manage_collections` (`eden_search` kept)
- `abraham_publish`, `abraham_seed`, `abraham_remember` out of Abraham's toolset (`daily`/`covenant`/`rest` kept — all in active use)

All pruning is comment-out with dated notes for easy restore.

## Testing
- `pytest tests -k "cache or llm or anthropic or session_post"` → 6 passed
- Unit assertions: no-cache path produces plain system string + unannotated messages; `_default_thinking_param` returns disabled only for sonnet-5; pricing/structured-output routing verified

## Not included (deliberate)
- Conductor/`automatic.py` left untouched (legacy, 0 calls in 90d)
- No TTL changes — measured: blanket 1h TTL is net-negative at current traffic
- **Abraham (and solomon) switch to Sonnet 5 on deploy automatically** — agents store only a `model_profile`; the only two `high`-profile agents resolve their model from `MODEL_TIERS["high"][0]`, updated here as a clean replacement so the cross-provider fallback chain ([haiku, gpt-5.4-nano]) is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Round 2: empirical cache audit (payload diffing on a 59-call Farcaster session)

Two mechanisms were fully invalidating the prompt cache (`read=0`, 30–50k rewrite) on **every social notification** — the dominant cache waste for eve/abraham, whose traffic is mostly social triggers:

1. **`_restrict_social_tool` baked the triggering message hash into the tool schema** (`enum`/`default` on `reply_to`). Tools are position 0 of the cache prefix, so each new Farcaster/Twitter notification changed tool bytes and invalidated tools + system + all history. Now enforced at execution time (`_process_tool_calls` overwrites the param — stronger than a schema default); tool bytes stay stable. Channel/DM platforms keep the schema path (session-stable targets).
2. **`_inject_social_reminder` mutated history**: the "users cannot see your messages" note attached to the *latest* platform message, then moved when the next notification arrived — byte-breaking the prefix mid-history and pushing the nearest cache entry past Anthropic's 20-block breakpoint lookback. Now an ephemeral trailing user message.

Plus:
- **1h TTL on the static system block** (template-split prompts only). Measured gap distributions (eve: 17% of inter-call gaps >5m, 6% >1h; abraham: 30%/10%) make the 2× 1h write strictly cheaper than repeated 1.25× rewrites.
- **`FallbackChainProvider.prompt_stream`**: no longer falls over to the next provider after partial output (previously duplicated text to the consumer); pre-stream failures still fall over.
- solomon moved to `model_profile: medium` in prod DB (only abraham remains on `high`).

Verified: history/schema byte-stability unit tests, fallover replay tests, 12 pytest passing.
