### PR TITLE
fix(google): nano_banana_pro -> GA model gemini-3-pro-image (404 fix)

### DIFF
--- a/eve/tools/google/__init__.py
+++ b/eve/tools/google/__init__.py
@@ -446,7 +446,7 @@ async def nano_banana_handler(
 
     Args:
         args: Tool arguments (prompt, image_input, aspect_ratio, etc.)
-        model: GCP model name (gemini-2.5-flash-image or gemini-3-pro-image-preview)
+        model: GCP model name (gemini-2.5-flash-image or gemini-3-pro-image)
         fal_fallback_tool: Name of FAL tool to use as fallback (nano_banana_fal or nano_banana_pro_fal)
 
     Returns:

--- a/eve/tools/google/nano_banana_pro/handler.py
+++ b/eve/tools/google/nano_banana_pro/handler.py
@@ -12,6 +12,6 @@ async def handler(context: ToolContext):
     """
     return await nano_banana_handler(
         context.args,
-        model="gemini-3-pro-image-preview",
+        model="gemini-3-pro-image",
         fal_fallback_tool="nano_banana_pro_fal",
     )

--- a/eve/tools/google/nano_banana_pro/handler_gemini.py
+++ b/eve/tools/google/nano_banana_pro/handler_gemini.py
@@ -94,7 +94,7 @@ async def handler(context: ToolContext):
     # Make the API call
     response = await asyncio.to_thread(
         client.models.generate_content,
-        model="gemini-3-pro-image-preview",
+        model="gemini-3-pro-image",
         contents=contents,
         config=generation_config,
     )


### PR DESCRIPTION
## Problem
`nano_banana_pro` image generation throws **404 NOT_FOUND** on Google's `gemini-3-pro-image-preview` ("model not found or your project does not have access"). The preview model was **shut down 2026-06-25**; it must migrate to the GA name `gemini-3-pro-image` (Global endpoint, GA since 2026-05-28).

The non-pro sibling was migrated to its GA name in March (a3b5d644); the **pro** handler was missed. Every nano_banana_pro call 404s + retries → a retry storm spiking `run_task` load (~20 404s / 14s), which contributed to an api-prod request-queue backup on 2026-07-21.

## Fix
`gemini-3-pro-image-preview` → `gemini-3-pro-image` in the two pro handlers + docstring. Matches the established deprecation pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)