### PR TITLE
Nano banana: FAL fallback on 404/403, per-input-image pricing, cost_utils fixes

### DIFF
--- a/eve/tools/fal/nano_banana_2_fal/api.yaml
+++ b/eve/tools/fal/nano_banana_2_fal/api.yaml
@@ -2,7 +2,7 @@ name: Nano Banana 2 (FAL)
 description: Google's next-gen image generation and editing model via FAL.ai with resolution control and web search. Supports text-to-image and image editing.
 tip: Provide image_urls to enable editing mode. Supports multiple reference images. Use enable_web_search for current events or real-world references.
 output_type: image
-cost_estimate: '(resolution == "4K" ? 16 : resolution == "2K" ? 12 : resolution == "0.5K" ? 6 : 8) * num_images'
+cost_estimate: '((resolution == "4K" ? 18 : resolution == "2K" ? 14 : resolution == "0.5K" ? 7 : 9) + (enable_web_search ? 2 : 0)) * num_images'
 handler: modal
 thumbnail: app/nano_banana_pro.jpg
 visible: true

--- a/eve/tools/fal/nano_banana_fal/api.yaml
+++ b/eve/tools/fal/nano_banana_fal/api.yaml
@@ -2,7 +2,7 @@ name: Nano Banana (FAL)
 description: Google's image generation and editing model via FAL.ai. Supports text-to-image and image editing.
 tip: Provide image_urls to enable editing mode. Supports up to 14 reference images.
 output_type: image
-cost_estimate: 1 * num_images
+cost_estimate: 4.5 * num_images
 handler: modal
 thumbnail: app/nano_banana.jpg
 visible: false

--- a/eve/tools/fal/nano_banana_pro_fal/api.yaml
+++ b/eve/tools/fal/nano_banana_pro_fal/api.yaml
@@ -2,7 +2,7 @@ name: Nano Banana Pro (FAL)
 description: Google's advanced image generation and editing model via FAL.ai with resolution control and web search. Supports text-to-image and image editing.
 tip: Provide image_urls to enable editing mode. Supports up to 14 reference images. Use enable_web_search for current events or real-world references.
 output_type: image
-cost_estimate: 4 * num_images
+cost_estimate: '((resolution == "4K" ? 34 : 17) + (enable_web_search ? 2 : 0)) * num_images'
 handler: modal
 thumbnail: app/nano_banana_pro.jpg
 visible: false

--- a/eve/tools/google/__init__.py
+++ b/eve/tools/google/__init__.py
@@ -6,6 +6,7 @@ import tempfile
 from urllib.parse import urlparse
 
 import httpx
+import sentry_sdk
 from loguru import logger
 
 from google import genai
@@ -170,25 +171,40 @@ async def veo_handler(args: dict, model: str):
 # ---- Nano Banana (Image Generation) ----
 
 
+class NanoBananaGCPError(ValueError):
+    """A GCP-side nano banana failure, tagged with the HTTP status when we have one."""
+
+    def __init__(self, message: str, status_code: int = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+# Statuses FAL can serve instead: rate limits (429), capacity/server errors (5xx),
+# and model-availability errors (404 retired model id, 403 project not allowlisted).
+# 400 is excluded on purpose — a malformed request fails on FAL too.
+_FALLBACK_STATUS_CODES = frozenset({403, 404, 429, 500, 502, 503, 504})
+
+# Only used when the error carries no status code (e.g. an SDK-level failure).
+_FALLBACK_ERROR_TERMS = (
+    "rate limit",
+    "quota",
+    "server error",
+    "unavailable",
+    "overloaded",
+    "was not found",
+    "does not have access",
+)
+
+
 def _should_fallback_to_fal(error: Exception) -> bool:
     """Determine if error should trigger FAL fallback."""
+    status_code = getattr(error, "status_code", None)
+    if status_code is not None:
+        return status_code in _FALLBACK_STATUS_CODES
+    # Substring matching is a last resort: bare codes like "500" are deliberately
+    # not matched here since they collide with digits echoed back from the prompt.
     error_str = str(error).lower()
-    # Fallback on: rate limits (429), server errors (5xx), quota exceeded
-    return any(
-        term in error_str
-        for term in [
-            "rate limit",
-            "429",
-            "quota",
-            "server error",
-            "500",
-            "502",
-            "503",
-            "504",
-            "unavailable",
-            "overloaded",
-        ]
-    )
+    return any(term in error_str for term in _FALLBACK_ERROR_TERMS)
 
 
 def _map_args_to_fal(args: dict, is_pro: bool = False) -> dict:
@@ -362,17 +378,23 @@ async def _nano_banana_gcp(args: dict, model: str) -> dict:
                 delay *= 2
                 continue
             elif e.code == 429:
-                raise ValueError(
-                    "Rate limit 429 reached for this image model. Please try again later or use a different image model (e.g., model_preference='flux' or 'openai')."
+                raise NanoBananaGCPError(
+                    "Rate limit 429 reached for this image model. Please try again later or use a different image model (e.g., model_preference='flux' or 'openai').",
+                    status_code=429,
                 )
             elif e.code == 403:
-                raise ValueError(
-                    "Google API access denied. Please check your API credentials and quotas."
+                raise NanoBananaGCPError(
+                    "Google API access denied. Please check your API credentials and quotas.",
+                    status_code=403,
                 )
             elif e.code == 400:
-                raise ValueError(f"Invalid request to Google API: {e.message}")
+                raise NanoBananaGCPError(
+                    f"Invalid request to Google API: {e.message}", status_code=400
+                )
             else:
-                raise ValueError(f"Google API error ({e.code}): {e.message}")
+                raise NanoBananaGCPError(
+                    f"Google API error ({e.code}): {e.message}", status_code=e.code
+                )
 
         except genai_errors.ServerError as e:
             logger.error(
@@ -384,8 +406,9 @@ async def _nano_banana_gcp(args: dict, model: str) -> dict:
                 delay *= 2
                 continue
             else:
-                raise ValueError(
-                    f"Google API server error 5xx. Please try again later or use a different image model. ({e.code})"
+                raise NanoBananaGCPError(
+                    f"Google API server error 5xx. Please try again later or use a different image model. ({e.code})",
+                    status_code=e.code,
                 )
 
         except Exception as e:
@@ -467,6 +490,17 @@ async def nano_banana_handler(
             logger.info(
                 f"[NANO_BANANA] >>> FALLING BACK TO FAL <<< using {fal_fallback_tool}"
             )
+            # Fallover must be LOUD: FAL costs more per image than GCP, and a
+            # permanent 404/403 (retired model id, lost access) would otherwise
+            # look healthy forever while quietly eating the margin.
+            try:
+                sentry_sdk.capture_message(
+                    f"Nano banana fallover: GCP model={model} failed, "
+                    f"falling back to {fal_fallback_tool}. Error: {e}",
+                    level="warning",
+                )
+            except Exception:
+                pass
             result = await _nano_banana_fal_fallback(args, fal_fallback_tool)
             logger.info("[NANO_BANANA] FAL fallback succeeded")
             return result

--- a/eve/tools/google/nano_banana/api.yaml
+++ b/eve/tools/google/nano_banana/api.yaml
@@ -1,7 +1,8 @@
 name: Nano Banana
 description: Fast image generation and editing using Google's Gemini 2.5 Flash Image model
 tip: Use this for quick image generation tasks. Supports optional input images for editing.
-cost_estimate: 4
+# $0.039/output image + $0.000387 per input image, priced at ~15% markup on both terms
+cost_estimate: 4.5 + image_input.length * 0.045
 output_type: image
 visible: true
 active: true
@@ -21,8 +22,9 @@ parameters:
       type: image
     label: Input images
     description: Input images to transform or use as reference
+    max_length: 14
     tip: |-
-      Optional input images that will be used as context or reference for the generation. You can provide multiple images.
+      Optional input images that will be used as context or reference for the generation. You can provide multiple images (up to 14).
   aspect_ratio:
     type: string
     label: Aspect Ratio

--- a/eve/tools/google/nano_banana_pro/api.yaml
+++ b/eve/tools/google/nano_banana_pro/api.yaml
@@ -1,7 +1,8 @@
 name: Nano Banana Pro
 description: Generate and edit images using Google's Gemini 3 Pro Image model (Nano Banana Pro) with advanced reasoning capabilities
 tip: Use this for complex image generation and editing tasks. Supports multiple reference images.
-cost_estimate: 8
+# $0.134/output image ($0.24 at 4K) + $0.00112 per input image, ~20% markup on both terms
+cost_estimate: '(image_size == "4K" ? 29 : 16) + image_input.length * 0.13'
 output_type: image
 visible: true
 active: true
@@ -21,8 +22,9 @@ parameters:
       type: image
     label: Input images
     description: Input images to transform or use as reference
+    max_length: 14
     tip: |-
-      Optional input images that will be used as context or reference for the generation. You can provide multiple images.
+      Optional input images that will be used as context or reference for the generation. You can provide multiple images (up to 14).
   aspect_ratio:
     type: string
     label: Aspect Ratio

--- a/eve/utils/cost_utils.py
+++ b/eve/utils/cost_utils.py
@@ -164,14 +164,30 @@ def _build_expression_parser(variables: Dict[str, Any]) -> ParserElement:
         for i in range(1, len(tokens)):
             accessor_token = tokens[i]
             if accessor_token == "length":
-                try:
-                    val = len(val)
-                except TypeError as e:
-                    raise ValueError(
-                        f"Cannot take .length of value of type {type(val).__name__}"
-                    ) from e
-            elif isinstance(accessor_token, int):
-                # Array index access
+                # None → 0 rather than an error: parse actions evaluate eagerly
+                # (both ternary branches always run), so `arr ? arr.length : 0`
+                # would otherwise blow up whenever the array param is absent.
+                if val is None:
+                    val = 0
+                else:
+                    try:
+                        val = len(val)
+                    except TypeError as e:
+                        raise ValueError(
+                            f"Cannot take .length of value of type {type(val).__name__}"
+                        ) from e
+            elif isinstance(accessor_token, (int, float)) and not isinstance(
+                accessor_token, bool
+            ):
+                # Array index access. The grammar parses bare integers like
+                # [0] as floats (real is tried before integer), so accept
+                # integral floats as indexes too.
+                if isinstance(accessor_token, float):
+                    if not accessor_token.is_integer():
+                        raise ValueError(
+                            f"Array index must be an integer, got {accessor_token}"
+                        )
+                    accessor_token = int(accessor_token)
                 try:
                     val = val[accessor_token]
                 except (IndexError, KeyError, TypeError) as e:
@@ -185,7 +201,10 @@ def _build_expression_parser(variables: Dict[str, Any]) -> ParserElement:
                     val = val.get(prop)
                 else:
                     val = getattr(val, prop, None)
-        return val
+        # Wrap: a bare list return gets spliced into the token stream by
+        # pyparsing (['a','b'] becomes two tokens, [] becomes zero), and a bare
+        # None return means "keep original tokens" instead of "value is None".
+        return [val]
 
     operand = (_base_operand + ZeroOrMore(accessor)).setParseAction(postfix_action)
 
@@ -289,7 +308,8 @@ def _build_expression_parser(variables: Dict[str, Any]) -> ParserElement:
     def ternary_action(tokens):
         # ``tokens`` is a list: [cond_val, true_val, false_val]
         cond_val, true_val, false_val = tokens
-        return true_val if cond_val else false_val
+        # Wrapped for the same list/None splicing reason as postfix_action.
+        return [true_val if cond_val else false_val]
 
     ternary.setParseAction(ternary_action)
 


### PR DESCRIPTION
## Context

`nano_banana_pro` broke on 2026-07-23 when Vertex retired `gemini-3-pro-image-preview` (GA id landed in #557). This PR is the rest of the incident follow-up: make the failure mode self-healing, and fix the family's pricing, which was underwater.

## FAL fallback hardening (`eve/tools/google/__init__.py`)

- Fallback now triggers on **404/403** (retired model id, lost project access) in addition to 429/5xx — the exact class of error #557 fixed would previously raise straight to the user despite a working FAL fallback being configured.
- GCP errors carry their HTTP status via `NanoBananaGCPError`; status-code matching replaces substring matching. Bare `"500"`/`"502"` substrings removed — they matched digits echoed back from user prompts.
- Fallover fires a Sentry warning (same pattern as the LLM provider fallover in `eve/agent/llm/llm.py`) — FAL costs more per image than GCP, so a silent permanent fallover would quietly eat margin.

## cost_utils evaluator fixes (`eve/utils/cost_utils.py`)

Three bugs that made array-valued params unusable in `cost_estimate` expressions:

1. Parse actions returned bare values — pyparsing **splices** a returned list into the token stream (2-element array → 2 tokens; empty array → vanishes) and treats returned `None` as "keep original tokens". Now wrapped.
2. `.length` of `None`/absent → `0` instead of raising. Parse actions evaluate eagerly (both ternary branches always run), so this is the only workable semantic.
3. Bracket indexes parse as floats (`[0]` → `0.0`), so array indexing **never worked** — fell through to `getattr(x, "0.0")` → `None`. Integral floats now accepted.

Verified: 18-case unit suite + an old-vs-new diff over **all 195 live `cost_estimate` expressions in prod tools3** — zero behavior changes (4 previously-crashing edge cases now degrade gracefully).

## Repricing (target 10–20% markup, 1 manna = $0.01)

Measured provider costs: Gemini 2.5 Flash Image $0.039/img (+$0.000387/input img); Gemini 3 Pro Image $0.134 @1K/2K, $0.24 @4K (+$0.00112/input img); FAL nano-banana $0.039; FAL pro $0.15/$0.30 +$0.015 search; FAL nb2 $0.06/$0.08/$0.12/$0.16 +$0.015 search.

| tool | old | new | old margin | new margin |
|---|---|---|---|---|
| `nano_banana` | 4 | `4.5 + 0.045/input img` | +2.6% | ~15.4% flat |
| `nano_banana_pro` | 8 | `16 (29 @4K) + 0.13/input img` | **−40%** | 19.3–20.5% |
| `nano_banana_fal` | 1×n | 4.5×n | **−74%** | +15.4% |
| `nano_banana_pro_fal` | 4×n | 17/34 +2 search | **−73%** | 13.3–15.2% |
| `nano_banana_2_fal` | 6/8/12/16 | 7/9/14/18 +2 search | **0%** | 12.5–16.7% |

`image_input` on both google tools is now capped at `max_length: 14` (matches the FAL twins and Gemini's documented limit; prod data showed outlier calls with 20–72 images billed at flat price).

## Deployment state

Prices are **already live** in tools3 (PROD+STAGE, read back and verified) and both Modal apps are deployed with this code. Merging makes the deployed state canonical so the next CI push doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)