### PR TITLE
Fix: create's pro video tier was priced below what it routes to

### DIFF
--- a/eve/tools/media_utils/create/api.yaml
+++ b/eve/tools/media_utils/create/api.yaml
@@ -17,8 +17,13 @@ tip: |-
   Aspect ratio:
     - Use 16:9 (landscape), 1:1 (square), 9:16 (portrait) unless the user specifies otherwise.
     - If aspect_ratio != "auto", it overrides any aspect ratio inferred from references.
-# pro image tier covers gpt_image_2 high ($0.211/img) at ~+42%; standard covers nb2
-cost_estimate: '(output == "video" ? (((quality == "pro" ? 50 : 25) + (sound_effects ? 10 : 0)) * duration) : ((quality == "pro" ? 30 : 10) * n_samples))'
+# Image: pro tier covers gpt_image_2 high ($0.211/img) at ~+42%; standard covers nb2.
+# Video: the pro rate must cover the most expensive model pro can route to —
+# seedance2 at 1080p is 80 manna/s, so 50/s was losing ~60% on every pro video
+# (a 10s pro render billed 500 and cost 800). 85/s covers seedance2 1080p with a
+# small margin and comfortably covers veo3. Standard (25/s) is healthy: it routes
+# to kling_v3 (17/s), veo_31_lite (6/s) or wan_27 720p (12/s).
+cost_estimate: '(output == "video" ? (((quality == "pro" ? 85 : 25) + (sound_effects ? 10 : 0)) * duration) : ((quality == "pro" ? 30 : 10) * n_samples))'
 output_type: image
 active: true
 visible: true

--- a/eve/tools/media_utils/create/handler.py
+++ b/eve/tools/media_utils/create/handler.py
@@ -1429,8 +1429,10 @@ async def handle_video_creation(
             aspect_ratio, "veo3", start_image_attributes
         )
 
-        # Veo can only produce 5-8s videos
-        duration = 4 if duration < 5 else 6 if duration < 7 else 8
+        # Veo only produces 4/6/8s. Round DOWN to the nearest supported length:
+        # create bills the user's requested duration, so rounding UP made veo3
+        # cost more than we charged (a 5s request ran 6s = 360 against a 250 bill).
+        duration = 8 if duration >= 8 else 6 if duration >= 6 else 4
 
         args = {
             "prompt": f"{prompt}. AUDIO: {sound_effects}" if sound_effects else prompt,


### PR DESCRIPTION
`create` bills before routing, at a flat per-second rate by quality. The pro rate (50/s) sat **below the cost of the models pro actually selects**, so every pro video lost money.

| 10s pro video | bills | costs | net |
|---|---|---|---|
| → seedance2 @1080p | 500 | **800** | **−300** |
| → veo3 | 500 | 480–600 | ~0 to −100 |

This lost money at **every** duration 5–10s.

## Fixes
- **Pro video rate 50 → 85 manna/s.** seedance2 1080p (80/s retail ≈ 67/s provider cost) now carries a **~21% margin**, matching the platform target; veo3 is comfortably covered.
- **veo3 duration now rounds DOWN** to the nearest supported 4/6/8s. create bills the user's requested duration, so rounding *up* made a 5s request run 6s and cost 360 against a 250 bill.
- **Standard tier untouched** (25/s) — it routes to kling_v3 (17/s), veo_31_lite (6/s), wan_27 720p (12/s) and was already healthy.

## Exposure
**Zero.** 0 pro-video runs in the last 30 days (of 2150 create runs: 1489 standard image, 472 standard video, 189 pro image). This is a latent leak that would start firing now that premium models are live — not a historical loss.

## Verification
- Every pro route billed above cost at all durations 5–10s
- 26 unit tests pass
- `scripts/validate_create_dispatch.py` clean (2391 sub-tool calls)

Merging auto-deploys prod and auto-updates the `create` tool in tools3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)