### PR TITLE
fix: restore web search for abraham (sonnet-5 missed the allowlist)

### DIFF
--- a/eve/agent/llm/providers/anthropic.py
+++ b/eve/agent/llm/providers/anthropic.py
@@ -472,27 +472,23 @@ class AnthropicProvider(LLMProvider):
                 return True
         return False
 
-    def _supports_web_search(self, model_name: str) -> bool:
-        """Check if a model supports web search.
+    # Claude models that predate the web search tool. Everything from 3.5 on
+    # supports it, so this is a denylist rather than an allowlist: the previous
+    # allowlist silently dropped web_search the moment abraham moved to
+    # claude-sonnet-5 (2026-07-20), because no pattern matched the new name. A
+    # denylist fails open on the next model bump instead of failing silent.
+    _NO_WEB_SEARCH_MODELS = (
+        "claude-3-opus",
+        "claude-3-sonnet",
+        "claude-3-haiku",
+    )
 
-        Web search is available on Claude 3.7 Sonnet, 3.5 Sonnet, and 3.5 Haiku.
-        """
+    def _supports_web_search(self, model_name: str) -> bool:
+        """Check if a model supports Anthropic's server-side web search tool."""
         normalized = model_name.lower().strip()
-        # Web search supported models
-        web_search_patterns = [
-            "claude-3-7-sonnet",
-            "claude-3.7-sonnet",
-            "claude-3-5-sonnet",
-            "claude-3.5-sonnet",
-            "claude-3-5-haiku",
-            "claude-3.5-haiku",
-            "claude-sonnet-4",  # Newer naming
-            "claude-haiku-4",  # Newer naming
-        ]
-        for pattern in web_search_patterns:
-            if pattern in normalized:
-                return True
-        return False
+        if not normalized.startswith("claude-"):
+            return False
+        return not normalized.startswith(self._NO_WEB_SEARCH_MODELS)
 
     def _deferred_tools_enabled(self) -> bool:
         return os.getenv("FF_DEFERRED_TOOLS", "").lower() in {

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -265,3 +265,42 @@ async def test_anthropic_tool_calling():
         tool_call = response.tool_calls[0]
         assert tool_call.tool == "get_weather"
         assert "location" in tool_call.args
+
+
+def _anthropic_provider():
+    """Bare provider instance - _supports_web_search/_build_tools_payload need no client."""
+    from eve.agent.llm.providers.anthropic import AnthropicProvider
+
+    return AnthropicProvider.__new__(AnthropicProvider)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-sonnet-5",
+        "claude-opus-5",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "claude-3-5-sonnet-20241022",
+    ],
+)
+def test_web_search_enabled_for_current_models(model):
+    """Regression: the old allowlist missed claude-sonnet-5, so abraham (the only
+    'high' tier agent) silently lost web search when PR#555 moved that tier to
+    sonnet-5. Every current Claude model must keep the server-side tool."""
+    assert _anthropic_provider()._supports_web_search(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-3-opus-20240229", "gpt-5.4-nano", "gemini-3-flash-preview", ""],
+)
+def test_web_search_disabled_for_unsupported_models(model):
+    assert _anthropic_provider()._supports_web_search(model) is False
+
+
+def test_web_search_tool_appended_to_payload():
+    payload = _anthropic_provider()._build_tools_payload(
+        [{"name": "create", "input_schema": {}}], "claude-sonnet-5"
+    )
+    assert any(t.get("type", "").startswith("web_search_") for t in payload)


### PR DESCRIPTION
## What broke

`AnthropicProvider._supports_web_search` was a hardcoded substring allowlist:

```python
"claude-sonnet-4",  # Newer naming
"claude-haiku-4",   # Newer naming
```

`"claude-sonnet-4"` is not a substring of `"claude-sonnet-5"`. When #555 put `claude-sonnet-5` at the head of `MODEL_TIERS["high"]` (2026-07-20), `_build_tools_payload` silently stopped appending the `web_search_20250305` server tool. No exception, no log — Abraham just quietly lost the ability to search the web/news.

## Blast radius: Abraham only

Abraham is the **only** agent with `llm_settings.model_profile: "high"` (426 default + 318 explicit `medium`, 1 `high`). Everyone else runs `claude-haiku-4-5`, which still matched `"claude-haiku-4"`.

## Evidence from `llm_calls` (eden-prod)

Same day, same collection:

| model | n_tools | server_tools |
|---|---|---|
| `claude-haiku-4-5` | 10 | `['web_search_20250305']` |
| `claude-sonnet-5` | 14 | `[]` |

Every Abraham call since 07-22 (retention horizon) shows zero server tools.

## Fix

Invert the allowlist to a **denylist** over `claude-*`. Web search is supported on everything from 3.5 onward, so the only exclusions are the retired Claude 3.0 family. The next model bump now fails *open* rather than failing *silent* — which is the actual bug class here.

Regression tests cover the current lineup (sonnet-5, opus-5, sonnet-4-6, haiku-4-5, 3.5-sonnet), the negative cases (3-opus, gpt, gemini, empty), and that the tool actually lands in the assembled payload.

## Note for follow-up (not in this PR)

Three sibling allowlists have the identical failure shape and need checking on every model bump: `STRUCTURED_OUTPUT_MODELS`, `_ANTHROPIC_PRICE`, `_THINKING_DEFAULT_ON_MODELS`. Those three *were* updated in #555 — web search was the one that got missed.

Sonnet-5 also supports the newer `web_search_20260209` (dynamic filtering) variant; left on `_20250305` here since switching versions changes runtime behavior and cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)