### PR TITLE
fal v2: submit + verified webhook — no held containers (follow-up to #566)

### DIFF
--- a/eve/api/api.py
+++ b/eve/api/api.py
@@ -25,6 +25,7 @@ from eve.api.api_functions import (
     cleanup_stuck_triggers,
     memory2_process_cold_sessions_fn,
     run_task_replicate,
+    sweep_pending_fal_tasks_fn,
 )
 from eve.api.api_functions import (
     run as _run,
@@ -71,6 +72,7 @@ from eve.api.handlers import (
     handle_reaction,
     handle_realtime_tool,
     handle_refresh_discord_channels,
+    handle_fal_webhook,
     handle_replicate_webhook,
     handle_session_cancel,
     handle_session_fields_update,
@@ -235,6 +237,30 @@ async def replicate_webhook(request: Request):
         return {"status": "error", "message": f"Invalid webhook signature: {str(e)}"}
 
     return await handle_replicate_webhook(data)
+
+
+@web_app.post("/update-fal")
+async def fal_webhook(request: Request):
+    """Completion callback for fal queue requests (see FalTool.async_start_task).
+
+    Verified with fal's documented scheme: ED25519 over
+    request_id\\nuser_id\\ntimestamp\\nsha256_hex(body) against fal's JWKS keys,
+    +/-5 min timestamp tolerance.
+    """
+    from eve.tools.fal_tool import verify_fal_webhook
+
+    body = await request.body()
+    try:
+        verify_fal_webhook(body, request.headers)
+    except Exception as e:
+        return {"status": "error", "message": f"Invalid fal webhook: {str(e)}"}
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return {"status": "error", "message": "Invalid JSON body"}
+
+    return await handle_fal_webhook(data)
 
 
 @web_app.post("/triggers/run")
@@ -650,6 +676,7 @@ async def periodic_fn():
     """Single consolidated periodic worker (one scheduled fn for all of api)."""
     for fn in (
         run_scheduled_triggers_fn,  # fire due user/agent scheduled sessions
+        sweep_pending_fal_tasks_fn,  # recover fal tasks whose webhook was missed
         cancel_stuck_tasks_fn,
         cleanup_stale_busy_states,
         cleanup_stuck_triggers,

--- a/eve/api/api_functions.py
+++ b/eve/api/api_functions.py
@@ -44,6 +44,66 @@ async def cancel_stuck_tasks_fn():
         sentry_sdk.capture_exception(e)
 
 
+async def sweep_pending_fal_tasks_fn():
+    """Backstop for missed fal completion webhooks.
+
+    The primary path is fal POSTing /update-fal; if a delivery is dropped, this
+    finds fal tasks still pending/running after a few minutes and finalizes
+    them from a direct status poll. fal_update_task is idempotent, so racing a
+    late webhook is safe. The 3h cancel_stuck_tasks watchdog remains the final
+    guard for anything even this misses.
+    """
+    import asyncio
+
+    import fal_client
+
+    from eve.tools.fal_tool import FalTool, fal_update_task
+
+    try:
+        tasks3 = get_collection("tasks3")
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=5)
+        candidates = list(
+            tasks3.find(
+                {
+                    "status": {"$in": ["pending", "running"]},
+                    "handler_id": {"$exists": True, "$nin": [None, ""]},
+                    "createdAt": {"$lt": cutoff},
+                }
+            ).limit(50)
+        )
+        for doc in candidates:
+            try:
+                task = Task.from_schema(doc)
+                tool = Tool.load(task.tool)
+                if not isinstance(tool, FalTool):
+                    continue  # modal/replicate/gcp tasks have their own paths
+                try:
+                    status = await asyncio.to_thread(
+                        fal_client.status,
+                        tool.fal_endpoint,
+                        task.handler_id,
+                        with_logs=False,
+                    )
+                except ValueError as e:
+                    # fal-client raises ValueError for FAILED / CANCELED
+                    msg = str(e)
+                    if "FAILED" in msg or "CANCELED" in msg:
+                        fal_update_task(task, "ERROR", None, msg)
+                        logger.info(f"fal sweep: finalized failed {task.id}")
+                    continue
+                if isinstance(status, fal_client.Completed):
+                    result = await asyncio.to_thread(
+                        fal_client.result, tool.fal_endpoint, task.handler_id
+                    )
+                    fal_update_task(task, "OK", result, None)
+                    logger.info(f"fal sweep: recovered completed {task.id}")
+            except Exception as e:
+                logger.warning(f"fal sweep: task {doc.get('_id')} failed: {e}")
+    except Exception as e:
+        logger.error(f"Error sweeping pending fal tasks: {e}")
+        sentry_sdk.capture_exception(e)
+
+
 async def generate_lora_thumbnails_fn():
     try:
         await generate_lora_thumbnails()

--- a/eve/api/handlers.py
+++ b/eve/api/handlers.py
@@ -297,6 +297,23 @@ async def handle_replicate_webhook(body: dict):
     return {"status": "success"}
 
 
+async def handle_fal_webhook(body: dict):
+    """Finalize a fal task from its completion webhook.
+
+    Payload: {request_id, gateway_request_id, status: "OK"|"ERROR",
+    payload: <result>, error?}. handler_id on the task is the fal request_id.
+    fal_update_task is idempotent (fal retries deliveries; the periodic sweep
+    and blocking waiters can race this).
+    """
+    from eve.tools.fal_tool import fal_update_task
+
+    task = Task.from_handler_id(body["request_id"])
+    _ = fal_update_task(
+        task, body.get("status"), body.get("payload"), body.get("error")
+    )
+    return {"status": "success"}
+
+
 @handle_errors
 async def handle_agent_tools_update(request: AgentToolsUpdateRequest):
     agent = Agent.from_mongo(ObjectId(request.agent_id))

--- a/eve/tools/fal_tool.py
+++ b/eve/tools/fal_tool.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 import os
 import re
+from datetime import datetime, timezone
 from typing import Any, List
 
 import fal_client
-import modal
 from pydantic import Field
 
 from .. import utils
@@ -229,52 +229,90 @@ class FalTool(Tool):
 
     @Tool.handle_start_task
     async def async_start_task(self, task: Task):
-        """Run the task to completion in a Modal container (blocking subscribe).
+        """Submit to fal's queue with a completion webhook; return immediately.
 
-        This previously submitted to fal's queue with a webhook and returned
-        immediately, but that path could never complete:
-          1. `webhook_url` was passed INSIDE `arguments`, while it is a
-             keyword-only parameter of fal_client.submit — fal ignores unknown
-             input keys, so it never received a callback URL at all; and
-          2. the only webhook endpoint (/update) validates Replicate signatures
-             and routes to the Replicate handler, so a fal callback would be
-             rejected anyway.
-        Tasks therefore sat pending until the >3h stuck-task watchdog killed
-        them as "Timed out" (every handler:fal tool, on every direct API/studio
-        call). Running through Modal's run_task is the same model the modal and
-        replicate tools use, and matches the eve/tools/fal/* tools that work.
+        The work runs on fal's servers — nothing on our side needs to stay
+        alive (no held Modal container, no polling). Completion arrives at
+        POST /update-fal (eve/api: handle_fal_webhook -> fal_update_task), and
+        a periodic sweep (sweep_pending_fal_tasks_fn) re-polls any fal task
+        still pending after a few minutes in case a webhook delivery is missed.
+
+        NOTE the historical bug this replaces: webhook_url MUST be the keyword
+        argument of fal_client.submit (it becomes the ?fal_webhook= query
+        param). It used to be buried inside `arguments`, where fal silently
+        ignores unknown keys — so no webhook was ever registered, nothing
+        polled, and every direct fal task hung until the 3h watchdog killed it
+        as "Timed out".
         """
         check_fal_api_token()
-        db = os.getenv("DB", "STAGE").upper()
-        func = modal.Function.from_name(
-            f"api-{db.lower()}", "run_task", environment_name="main"
+        args = self.prepare_args(task.args)
+        args = await asyncio.to_thread(self._format_args_for_fal, args)
+
+        handler = await asyncio.to_thread(
+            fal_client.submit,
+            self.fal_endpoint,
+            arguments=args,
+            webhook_url=get_webhook_url(),
         )
-        job = await func.spawn.aio(task)
-        return job.object_id
+        return handler.request_id
 
     @Tool.handle_wait
     async def async_wait(self, task: Task):
-        """Wait on the Modal job spawned by async_start_task.
+        """Poll fal until the request finishes (blocking callers only).
 
-        handler_id is now a Modal FunctionCall id (not a fal request id); the
-        run_task container updates the task itself, so we just await it.
+        The primary completion path is the webhook; this exists for callers
+        that need to block on a task. Finalization goes through
+        fal_update_task, which is idempotent, so racing the webhook is safe.
         """
-        fc = modal.functions.FunctionCall.from_id(task.handler_id)
-        await fc.get.aio()
-        task.reload()
-        return task.model_dump(include={"status", "error", "result"})
+        check_fal_api_token()
+        request_id = task.handler_id
+
+        while True:
+            task.reload()
+            if task.status in ("completed", "failed", "cancelled"):
+                return task.model_dump(include={"status", "error", "result"})
+
+            try:
+                status = await asyncio.to_thread(
+                    fal_client.status,
+                    self.fal_endpoint,
+                    request_id,
+                    with_logs=False,
+                )
+            except ValueError as e:
+                # fal-client raises ValueError for FAILED / CANCELED statuses
+                error_msg = str(e)
+                if "CANCELED" in error_msg:
+                    task.update(status="cancelled")
+                    task.refund_manna()
+                    return {"status": "cancelled"}
+                if "FAILED" in error_msg:
+                    return fal_update_task(task, "ERROR", None, error_msg)
+                raise
+
+            if isinstance(status, fal_client.InProgress):
+                if task.status != "running":
+                    task.update(status="running")
+            elif isinstance(status, fal_client.Completed):
+                result = await asyncio.to_thread(
+                    fal_client.result, self.fal_endpoint, request_id
+                )
+                return fal_update_task(task, "OK", result, None)
+
+            await asyncio.sleep(1)
 
     @Tool.handle_cancel
     async def async_cancel(self, task: Task):
-        """Cancel the Modal job (handler_id is a Modal FunctionCall id)."""
+        """Cancel the fal queue request (handler_id is the fal request id)."""
         if not task.handler_id:
             return
         try:
-            fc = modal.functions.FunctionCall.from_id(task.handler_id)
-            await fc.cancel.aio()
-            logger.info(f"Cancelled Modal job {task.handler_id}")
+            await asyncio.to_thread(
+                fal_client.cancel, self.fal_endpoint, task.handler_id
+            )
+            logger.info(f"FAL cancel sent for {task.handler_id}")
         except Exception as e:
-            logger.warning(f"Failed to cancel Modal job {task.handler_id}: {e}")
+            logger.warning(f"FAL cancel failed for {task.handler_id}: {e}")
 
     def _format_args_for_fal(self, args: dict):
         """Format the arguments for FAL API call"""
@@ -402,10 +440,156 @@ def get_webhook_url():
         else ""
     )
 
-    webhook_url = f"https://edenartlab--{env}-fastapi-app{dev}.modal.run/update"
+    # /update is the Replicate webhook (replicate signature validation);
+    # fal callbacks go to their own endpoint with fal's ED25519 scheme.
+    webhook_url = f"https://edenartlab--{env}-fastapi-app{dev}.modal.run/update-fal"
     return webhook_url
 
 
 def check_fal_api_token():
     if not os.getenv("FAL_KEY"):
         raise Exception("FAL_KEY is not set")
+
+
+# ---------------------------------------------------------------------------
+# Webhook-side finalization
+# ---------------------------------------------------------------------------
+
+def fal_update_task(task: Task, status: str, payload, error):
+    """Finalize a fal task from a webhook payload ({status: OK|ERROR, payload})
+    or from a status poll (async_wait / the periodic sweep).
+
+    IDEMPOTENT via the terminal-status guard: fal retries webhook deliveries,
+    and the sweep or a blocking waiter can race a webhook — only the first
+    finalizer runs; the rest no-op. Mirrors replicate_update_task.
+    """
+    task.reload()
+    if task.status in ("completed", "failed", "cancelled"):
+        return {"status": task.status}
+
+    if status != "OK":
+        error_msg = str(error or "fal returned an error")[:500]
+        task.update(status="failed", error=error_msg)
+        task.refund_manna()
+        return {"status": "failed", "error": error_msg}
+
+    tool = Tool.load(task.tool)
+    urls = tool._extract_urls_from_fal_result(payload or {})
+    if not urls:
+        error_msg = f"fal returned no output: {str(payload)[:300]}"
+        task.update(status="failed", error=error_msg)
+        task.refund_manna()
+        return {"status": "failed", "error": error_msg}
+
+    output = utils.upload_result(urls, save_thumbnails=True, save_blurhash=True)
+    result = [{"output": [out]} for out in output]
+
+    for r, res in enumerate(result):
+        for o, out in enumerate(res["output"]):
+            creation = Creation(
+                user=task.user,
+                agent=task.agent,
+                task=task.id,
+                tool=task.tool,
+                filename=out["filename"],
+                mediaAttributes=out["mediaAttributes"],
+                name=task.args.get("prompt"),
+                public=task.public,
+            )
+            creation.save()
+            result[r]["output"][o]["creation"] = creation.id
+
+    run_time = (
+        datetime.now(timezone.utc) - task.createdAt.replace(tzinfo=timezone.utc)
+    ).total_seconds()
+    task.performance["runTime"] = run_time
+    task.status = "completed"
+    task.result = result
+    task.save()
+    return {"status": "completed", "result": result}
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification (fal's documented scheme)
+#
+# Headers: X-Fal-Webhook-Request-Id, X-Fal-Webhook-User-Id,
+#          X-Fal-Webhook-Timestamp, X-Fal-Webhook-Signature (hex)
+# Message: "\n".join(request_id, user_id, timestamp, sha256_hex(raw_body))
+# Verify:  ED25519 against any key from fal's JWKS (keys[].x is a base64url
+#          ED25519 public key); timestamp must be within +/-5 minutes.
+# Verified against fal's docs and two independent SDK implementations.
+# ---------------------------------------------------------------------------
+
+FAL_JWKS_URL = "https://rest.alpha.fal.ai/.well-known/jwks.json"
+_FAL_JWKS_TTL = 24 * 3600  # fal say keys may rotate; don't cache longer than 24h
+_fal_jwks_cache = {"keys": None, "fetched_at": 0.0}
+
+
+def _get_fal_public_keys():
+    import base64
+    import time
+
+    import httpx
+
+    now = time.time()
+    if (
+        _fal_jwks_cache["keys"]
+        and now - _fal_jwks_cache["fetched_at"] < _FAL_JWKS_TTL
+    ):
+        return _fal_jwks_cache["keys"]
+
+    resp = httpx.get(FAL_JWKS_URL, timeout=10)
+    resp.raise_for_status()
+    keys = []
+    for jwk in resp.json().get("keys", []):
+        x = jwk.get("x")
+        if not x:
+            continue
+        pad = "=" * (-len(x) % 4)
+        keys.append(base64.urlsafe_b64decode(x + pad))
+    if keys:
+        _fal_jwks_cache.update(keys=keys, fetched_at=now)
+    return keys
+
+
+def verify_fal_webhook(body: bytes, headers) -> None:
+    """Raise ValueError unless this is an authentic, fresh fal webhook."""
+    import hashlib
+    import time
+
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    def h(name):
+        value = headers.get(name)
+        if not value:
+            raise ValueError(f"missing header {name}")
+        return value
+
+    request_id = h("X-Fal-Webhook-Request-Id")
+    user_id = h("X-Fal-Webhook-User-Id")
+    timestamp = h("X-Fal-Webhook-Timestamp")
+    signature_hex = h("X-Fal-Webhook-Signature")
+
+    try:
+        skew = abs(time.time() - int(timestamp))
+    except ValueError:
+        raise ValueError("invalid timestamp header")
+    if skew > 300:
+        raise ValueError(f"timestamp outside tolerance ({skew:.0f}s)")
+
+    message = "\n".join(
+        [request_id, user_id, timestamp, hashlib.sha256(body).hexdigest()]
+    ).encode()
+    try:
+        signature = bytes.fromhex(signature_hex)
+    except ValueError:
+        raise ValueError("signature is not valid hex")
+
+    for key_bytes in _get_fal_public_keys():
+        try:
+            Ed25519PublicKey.from_public_bytes(key_bytes).verify(signature, message)
+            return
+        except (InvalidSignature, ValueError):
+            continue
+    raise ValueError("signature did not verify against any fal public key")

--- a/tests/test_fal_webhook.py
+++ b/tests/test_fal_webhook.py
@@ -1,0 +1,141 @@
+"""fal webhook path: signature verification + task finalization.
+
+The verification recipe (message = request_id\nuser_id\ntimestamp\n
+sha256_hex(body), ED25519 against JWKS keys, +/-5 min tolerance) matches fal's
+documented scheme; these tests prove our implementation of it with a real
+keypair, and prove fal_update_task's status mapping and idempotency.
+"""
+
+import hashlib
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from eve.tools import fal_tool
+from eve.tools.fal_tool import fal_update_task, verify_fal_webhook
+
+
+# ---------------------------------------------------------------------------
+# signature verification
+# ---------------------------------------------------------------------------
+
+def _signed_request(body: bytes, ts_offset: int = 0):
+    key = Ed25519PrivateKey.generate()
+    pub = key.public_key().public_bytes_raw()
+    request_id = "req-123"
+    user_id = "user-456"
+    timestamp = str(int(time.time()) + ts_offset)
+    message = "\n".join(
+        [request_id, user_id, timestamp, hashlib.sha256(body).hexdigest()]
+    ).encode()
+    signature = key.sign(message).hex()
+    headers = {
+        "X-Fal-Webhook-Request-Id": request_id,
+        "X-Fal-Webhook-User-Id": user_id,
+        "X-Fal-Webhook-Timestamp": timestamp,
+        "X-Fal-Webhook-Signature": signature,
+    }
+    return headers, pub
+
+
+def test_signature_verifies():
+    body = b'{"request_id": "req-123", "status": "OK"}'
+    headers, pub = _signed_request(body)
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        verify_fal_webhook(body, headers)  # should not raise
+
+
+def test_tampered_body_rejected():
+    body = b'{"status": "OK"}'
+    headers, pub = _signed_request(body)
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        with pytest.raises(ValueError, match="did not verify"):
+            verify_fal_webhook(b'{"status": "HACKED"}', headers)
+
+
+def test_stale_timestamp_rejected():
+    body = b"{}"
+    headers, pub = _signed_request(body, ts_offset=-600)  # 10 min old
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        with pytest.raises(ValueError, match="tolerance"):
+            verify_fal_webhook(body, headers)
+
+
+def test_wrong_key_rejected():
+    body = b"{}"
+    headers, _ = _signed_request(body)
+    other = Ed25519PrivateKey.generate().public_key().public_bytes_raw()
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[other]):
+        with pytest.raises(ValueError, match="did not verify"):
+            verify_fal_webhook(body, headers)
+
+
+def test_missing_header_rejected():
+    body = b"{}"
+    headers, pub = _signed_request(body)
+    del headers["X-Fal-Webhook-Signature"]
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        with pytest.raises(ValueError, match="missing header"):
+            verify_fal_webhook(body, headers)
+
+
+# ---------------------------------------------------------------------------
+# fal_update_task
+# ---------------------------------------------------------------------------
+
+def _task(status="pending"):
+    task = MagicMock()
+    task.status = status
+    task.args = {"prompt": "a cat"}
+    task.performance = {}
+    task.reload = MagicMock()
+    return task
+
+
+def test_error_payload_fails_task_and_refunds():
+    task = _task()
+    out = fal_update_task(task, "ERROR", None, "Invalid status code: 422")
+    assert out["status"] == "failed"
+    task.update.assert_called_once()
+    assert task.update.call_args.kwargs["status"] == "failed"
+    task.refund_manna.assert_called_once()
+
+
+def test_idempotent_when_terminal():
+    """fal retries webhook deliveries; a second delivery must no-op."""
+    for terminal in ("completed", "failed", "cancelled"):
+        task = _task(status=terminal)
+        out = fal_update_task(task, "OK", {"video": {"url": "http://x"}}, None)
+        assert out["status"] == terminal
+        task.update.assert_not_called()
+        task.refund_manna.assert_not_called()
+
+
+def test_ok_payload_completes_with_creation():
+    task = _task()
+    tool = MagicMock()
+    tool._extract_urls_from_fal_result.return_value = ["https://fal/video.mp4"]
+    uploaded = [{"filename": "abc.mp4", "mediaAttributes": {"duration": 3}}]
+    with patch.object(fal_tool.Tool, "load", return_value=tool), \
+         patch.object(fal_tool.utils, "upload_result", return_value=uploaded), \
+         patch.object(fal_tool, "Creation") as MockCreation:
+        MockCreation.return_value.id = "creation-id"
+        out = fal_update_task(task, "OK", {"video": {"url": "https://fal/video.mp4"}}, None)
+    assert out["status"] == "completed"
+    assert task.status == "completed"
+    assert task.result[0]["output"][0]["creation"] == "creation-id"
+    MockCreation.return_value.save.assert_called_once()
+    task.save.assert_called()
+    task.refund_manna.assert_not_called()
+
+
+def test_empty_result_fails_and_refunds():
+    task = _task()
+    tool = MagicMock()
+    tool._extract_urls_from_fal_result.return_value = []
+    with patch.object(fal_tool.Tool, "load", return_value=tool):
+        out = fal_update_task(task, "OK", {}, None)
+    assert out["status"] == "failed"
+    task.refund_manna.assert_called_once()


### PR DESCRIPTION
**#566 was merged 14 minutes before the v2 commit landed on the branch**, so prod is running v1 (Modal container blocking-polls fal — functional, but holds a container for the full render and adds a cold-start before submit). This PR is exactly that missing commit: the architecture review follow-up.

## What v2 changes (one commit, `233f6d41`)
- **`async_start_task`**: instant `fal_client.submit(..., webhook_url=...)` (proper kwarg → `?fal_webhook=`), returns the fal request_id. No container, no polling, no cold-start before fal receives the job.
- **`POST /update-fal`** (new): fal's completion callback, verified per fal's documented scheme — ED25519 over `request_id\nuser_id\ntimestamp\nsha256_hex(body)` against fal's JWKS keys, ±5 min tolerance. Scheme confirmed against fal docs + two independent SDK implementations.
- **`fal_update_task`**: idempotent finalizer mirroring `replicate_update_task` (uploads, Creations, refund on error) — fal retries deliveries, so idempotency is load-bearing.
- **Backstop sweep** in the 5-min periodic cron re-polls fal tasks pending >5 min (missed webhooks). 3h watchdog stays as last resort.
- `async_wait` polls fal for blocking callers via the same finalizer; `async_cancel` cancels the fal queue request.

## Verification
52 tests pass (real-keypair ED25519 round-trip: tamper/stale/wrong-key/missing-header all rejected; finalizer mapping + idempotency) **plus an e2e through FastAPI TestClient**: signed POST → 200 → task found by request_id → finalized; unsigned → rejected. Dispatch sweep clean (2391 calls).

**After deploy, confirm**: `curl -X POST https://edenartlab--api-prod-fastapi-app.modal.run/update-fal -d '{}'` returns `Invalid fal webhook: missing header...` (today it 404s = v1), then one studio kling_v3 run completes in render-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)