### PR TITLE
fal webhook hardening (finish-pass commit that missed the #567 merge)

### DIFF
--- a/eve/api/api.py
+++ b/eve/api/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -67,12 +68,12 @@ from eve.api.handlers import (
     handle_create_notification,
     handle_embedsearch,
     handle_extract_agent_prompts,
+    handle_fal_webhook,
     handle_get_discord_channels,
     handle_prompt_session,
     handle_reaction,
     handle_realtime_tool,
     handle_refresh_discord_channels,
-    handle_fal_webhook,
     handle_replicate_webhook,
     handle_session_cancel,
     handle_session_fields_update,
@@ -245,20 +246,31 @@ async def fal_webhook(request: Request):
 
     Verified with fal's documented scheme: ED25519 over
     request_id\\nuser_id\\ntimestamp\\nsha256_hex(body) against fal's JWKS keys,
-    +/-5 min timestamp tolerance.
+    +/-5 min timestamp tolerance. Rejections return 401 with a GENERIC message
+    (the detail is logged, not echoed — the skew detail is a clock oracle) and
+    a non-2xx status so fal retries transient failures like a JWKS blip.
     """
     from eve.tools.fal_tool import verify_fal_webhook
 
     body = await request.body()
     try:
-        verify_fal_webhook(body, request.headers)
+        # to_thread: verification may do a blocking JWKS fetch (up to 10s);
+        # never on the event loop of the whole API.
+        await asyncio.to_thread(verify_fal_webhook, body, request.headers)
     except Exception as e:
-        return {"status": "error", "message": f"Invalid fal webhook: {str(e)}"}
+        logger.warning(f"rejected fal webhook: {e}")
+        return JSONResponse(
+            status_code=401,
+            content={"status": "error", "message": "invalid fal webhook signature"},
+        )
 
     try:
         data = json.loads(body)
     except json.JSONDecodeError:
-        return {"status": "error", "message": "Invalid JSON body"}
+        return JSONResponse(
+            status_code=400,
+            content={"status": "error", "message": "invalid JSON body"},
+        )
 
     return await handle_fal_webhook(data)
 

--- a/eve/api/api_functions.py
+++ b/eve/api/api_functions.py
@@ -49,34 +49,50 @@ async def sweep_pending_fal_tasks_fn():
 
     The primary path is fal POSTing /update-fal; if a delivery is dropped, this
     finds fal tasks still pending/running after a few minutes and finalizes
-    them from a direct status poll. fal_update_task is idempotent, so racing a
-    late webhook is safe. The 3h cancel_stuck_tasks watchdog remains the final
-    guard for anything even this misses.
+    them from a direct status poll. fal_update_task claims atomically, so
+    racing a late webhook is safe. The 3h cancel_stuck_tasks watchdog remains
+    the final guard for anything even this misses.
+
+    fal reports FAILED jobs as status COMPLETED — the failure only surfaces
+    when the result fetch raises with a 4xx (there is no FAILED/CANCELED
+    status in fal's queue enum), so error recovery hangs off the result call.
     """
     import asyncio
 
     import fal_client
 
-    from eve.tools.fal_tool import FalTool, fal_update_task
+    from eve.tools.fal_tool import _falclient_status_code, fal_update_task
 
     try:
         tasks3 = get_collection("tasks3")
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=5)
+
+        # Restrict the query to fal tools, and sweep oldest-first — without
+        # both, 50 pending long-running modal/replicate tasks would pin the
+        # window and starve the backstop exactly when the platform is busy.
+        fal_tool_keys = [
+            d["key"]
+            for d in get_collection("tools3").find({"handler": "fal"}, {"key": 1})
+        ]
+        if not fal_tool_keys:
+            return
+
         candidates = list(
             tasks3.find(
                 {
+                    "tool": {"$in": fal_tool_keys},
                     "status": {"$in": ["pending", "running"]},
                     "handler_id": {"$exists": True, "$nin": [None, ""]},
                     "createdAt": {"$lt": cutoff},
                 }
-            ).limit(50)
+            )
+            .sort("createdAt", 1)
+            .limit(50)
         )
         for doc in candidates:
             try:
                 task = Task.from_schema(doc)
                 tool = Tool.load(task.tool)
-                if not isinstance(tool, FalTool):
-                    continue  # modal/replicate/gcp tasks have their own paths
                 try:
                     status = await asyncio.to_thread(
                         fal_client.status,
@@ -84,19 +100,30 @@ async def sweep_pending_fal_tasks_fn():
                         task.handler_id,
                         with_logs=False,
                     )
-                except ValueError as e:
-                    # fal-client raises ValueError for FAILED / CANCELED
-                    msg = str(e)
-                    if "FAILED" in msg or "CANCELED" in msg:
-                        fal_update_task(task, "ERROR", None, msg)
-                        logger.info(f"fal sweep: finalized failed {task.id}")
+                except Exception as e:
+                    logger.warning(f"fal sweep: status poll {task.id} failed: {e}")
                     continue
-                if isinstance(status, fal_client.Completed):
+                if not isinstance(status, fal_client.Completed):
+                    continue  # still queued/running at fal; next sweep re-checks
+                try:
                     result = await asyncio.to_thread(
                         fal_client.result, tool.fal_endpoint, task.handler_id
                     )
-                    fal_update_task(task, "OK", result, None)
-                    logger.info(f"fal sweep: recovered completed {task.id}")
+                except Exception as e:
+                    code = _falclient_status_code(e)
+                    if code is not None and 400 <= code < 500:
+                        # The JOB failed — finalize + refund.
+                        await asyncio.to_thread(
+                            fal_update_task, task, "ERROR", None, str(e)
+                        )
+                        logger.info(f"fal sweep: finalized failed {task.id}")
+                    else:
+                        logger.warning(
+                            f"fal sweep: result fetch {task.id} failed: {e}"
+                        )
+                    continue
+                await asyncio.to_thread(fal_update_task, task, "OK", result, None)
+                logger.info(f"fal sweep: recovered completed {task.id}")
             except Exception as e:
                 logger.warning(f"fal sweep: task {doc.get('_id')} failed: {e}")
     except Exception as e:

--- a/eve/api/handlers.py
+++ b/eve/api/handlers.py
@@ -302,16 +302,41 @@ async def handle_fal_webhook(body: dict):
 
     Payload: {request_id, gateway_request_id, status: "OK"|"ERROR",
     payload: <result>, error?}. handler_id on the task is the fal request_id.
-    fal_update_task is idempotent (fal retries deliveries; the periodic sweep
-    and blocking waiters can race this).
+    fal_update_task claims the task atomically (fal retries deliveries; the
+    periodic sweep and blocking waiters can race this).
     """
+    from fastapi.responses import JSONResponse
+
     from eve.tools.fal_tool import fal_update_task
 
-    task = Task.from_handler_id(body["request_id"])
-    _ = fal_update_task(
-        task, body.get("status"), body.get("payload"), body.get("error")
+    request_id = body.get("request_id")
+    if not isinstance(request_id, str) or not request_id:
+        # Type check matters: a JSON object here would reach the Mongo query
+        # as operators. The signature gates this, but defense in depth is one line.
+        return JSONResponse(
+            status_code=400,
+            content={"status": "error", "message": "invalid request_id"},
+        )
+
+    try:
+        task = Task.from_handler_id(request_id)
+    except Exception:
+        # No such task. Either a delivery that beat the handler_id write (the
+        # 404 makes fal retry, which resolves it) or a signed delivery for a
+        # job that isn't ours. Never a 500 — that burns Sentry budget on
+        # attacker-fillable traffic.
+        logger.warning(f"fal webhook for unknown request_id {request_id[:64]}")
+        return JSONResponse(
+            status_code=404,
+            content={"status": "error", "message": "unknown request_id"},
+        )
+
+    # to_thread: finalization downloads media and uploads to S3 — never on the
+    # API's event loop (a slow video would stall every request in the container).
+    result = await asyncio.to_thread(
+        fal_update_task, task, body.get("status"), body.get("payload"), body.get("error")
     )
-    return {"status": "success"}
+    return {"status": "success", "task": result.get("status")}
 
 
 @handle_errors

--- a/eve/tools/fal_tool.py
+++ b/eve/tools/fal_tool.py
@@ -2,16 +2,15 @@ import asyncio
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, List
 
 import fal_client
 from pydantic import Field
 
 from .. import utils
+from ..mongo import get_collection
 from ..task import Creation, Task
-
-# from ..agent.session.models import Session
 from ..tool import Tool, ToolContext, tool_context
 
 logger = logging.getLogger(__name__)
@@ -262,14 +261,21 @@ class FalTool(Tool):
 
         The primary completion path is the webhook; this exists for callers
         that need to block on a task. Finalization goes through
-        fal_update_task, which is idempotent, so racing the webhook is safe.
+        fal_update_task, which claims the task atomically, so racing the
+        webhook is safe.
+
+        NOTE on failure detection: fal's queue status enum is only
+        IN_QUEUE / IN_PROGRESS / COMPLETED — a FAILED job also reports
+        COMPLETED, and the failure only surfaces when the result fetch raises
+        (4xx). There is no FAILED/CANCELED status to branch on (verified
+        against fal_client 0.5.9 _parse_status).
         """
         check_fal_api_token()
         request_id = task.handler_id
 
         while True:
             task.reload()
-            if task.status in ("completed", "failed", "cancelled"):
+            if task.status in TERMINAL_STATES:
                 return task.model_dump(include={"status", "error", "result"})
 
             try:
@@ -279,25 +285,36 @@ class FalTool(Tool):
                     request_id,
                     with_logs=False,
                 )
-            except ValueError as e:
-                # fal-client raises ValueError for FAILED / CANCELED statuses
-                error_msg = str(e)
-                if "CANCELED" in error_msg:
-                    task.update(status="cancelled")
-                    task.refund_manna()
-                    return {"status": "cancelled"}
-                if "FAILED" in error_msg:
-                    return fal_update_task(task, "ERROR", None, error_msg)
-                raise
+            except Exception as e:
+                # Transient status-endpoint failure (or an unknown status
+                # string) — keep polling; the watchdog bounds the loop.
+                logger.warning(f"fal status poll failed for {request_id}: {e}")
+                await asyncio.sleep(2)
+                continue
 
             if isinstance(status, fal_client.InProgress):
                 if task.status != "running":
                     task.update(status="running")
             elif isinstance(status, fal_client.Completed):
-                result = await asyncio.to_thread(
-                    fal_client.result, self.fal_endpoint, request_id
+                try:
+                    result = await asyncio.to_thread(
+                        fal_client.result, self.fal_endpoint, request_id
+                    )
+                except Exception as e:
+                    code = _falclient_status_code(e)
+                    if code is not None and 400 <= code < 500:
+                        # The JOB failed (fal returns 4xx on the result of a
+                        # failed run); finalize as an error + refund.
+                        return await asyncio.to_thread(
+                            fal_update_task, task, "ERROR", None, str(e)
+                        )
+                    # Transient (5xx / network): retry the loop.
+                    logger.warning(f"fal result fetch failed for {request_id}: {e}")
+                    await asyncio.sleep(2)
+                    continue
+                return await asyncio.to_thread(
+                    fal_update_task, task, "OK", result, None
                 )
-                return fal_update_task(task, "OK", result, None)
 
             await asyncio.sleep(1)
 
@@ -325,106 +342,6 @@ class FalTool(Tool):
                 new_args[key] = fal_client.upload_file(value)
 
         return new_args
-
-    def _get_value_by_path(self, data: Any, path: List[str]) -> Any:
-        """Retrieve value from nested data using a list of keys (path)."""
-        current = data
-        for key in path:
-            if isinstance(current, dict) and key in current:
-                current = current[key]
-            elif (
-                isinstance(current, list) and key.isdigit() and int(key) < len(current)
-            ):
-                # This part might need refinement if arrays are complex
-                # For now, assumes path doesn't navigate *into* array elements using numeric indices
-                # The path finding logic returns the path *to* the array itself
-                current = current[int(key)]
-            else:
-                return None  # Path not found or invalid structure
-        return current
-
-    def _process_result(self, result, task):
-        """Process the result from FAL API by extracting URLs from common response structures."""
-
-        # Extract URLs using common FAL response patterns
-        output_urls = self._extract_urls_from_fal_result(result)
-
-        if not output_urls:
-            logger.error(
-                f"No output URLs extracted from FAL result for tool {self.name}, task {task.id}. Returning raw result."
-            )
-            return {"output": result}  # Return raw result if extraction fails
-
-        processed_outputs = []
-        # Upload each extracted URL
-        for url in output_urls:
-            try:
-                # upload_result expects a dict structure. We wrap the single URL.
-                # It will upload the URL and return metadata.
-                logger.info(f"Attempting to upload FAL URL to Eden: {url}")
-                uploaded_data = utils.upload_result(
-                    {"output": url},  # Pass the URL directly for uploading
-                    save_thumbnails=True,
-                    save_blurhash=True,
-                )
-                # Print the result from upload_result to see the structure and final URL
-                logger.info(f"Uploaded FAL URL {url} to Eden: {uploaded_data}")
-                # Unwrap the "output" key since upload_result preserves the dict structure
-                processed_outputs.append(uploaded_data.get("output", uploaded_data))
-            except Exception as e:
-                logger.error(f"Failed to upload result URL {url}: {e}")
-                continue  # Skip this output if upload fails
-
-        if not processed_outputs:
-            logger.error(f"No processable outputs found or uploaded for task {task.id}")
-            # Return raw result if processing/uploading failed
-            return {"output": result}
-
-        # Structure for database: match replicate format - each output gets its own result entry
-        # This matches: result = [{"output": [out]} for out in output]
-        final_result_structure = [{"output": [out]} for out in processed_outputs]
-
-        # Create creation object(s) based on processed outputs
-        for r, res_item in enumerate(final_result_structure):
-            for o, output_data in enumerate(res_item["output"]):
-                # Ensure output_data is a dict, as expected by Creation logic
-                if not isinstance(output_data, dict):
-                    logger.warning(
-                        f"Skipping creation object for non-dict output: {output_data}"
-                    )
-                    continue
-
-                name = task.args.get(
-                    "prompt", task.args.get("text_input", "")
-                )  # Try getting prompt/text_input
-
-                # creation_agent = task.agent
-                # session = Session.from_mongo(task.session)
-                # if session.parent_session:
-                #     parent_session = Session.from_mongo(session.parent_session)
-                #     creation_agent = parent_session.agent
-
-                creation = Creation(
-                    user=task.user,
-                    # agent=creation_agent,
-                    agent=task.agent,
-                    task=task.id,
-                    tool=task.tool,
-                    filename=output_data.get("filename"),
-                    mediaAttributes=output_data.get("mediaAttributes", {}),
-                    name=name,
-                    public=task.public,
-                )
-                creation.save()
-                final_result_structure[r]["output"][o]["creation"] = creation.id
-
-        return final_result_structure  # Return the structured result with creation IDs
-
-    # Override the base class method to add debugging before returning
-    async def wait(self, task: Task):
-        result_data = await self.async_wait(task)
-        return result_data
-
 
 def get_webhook_url():
     env = {
@@ -455,16 +372,49 @@ def check_fal_api_token():
 # Webhook-side finalization
 # ---------------------------------------------------------------------------
 
+TERMINAL_STATES = ("completed", "failed", "cancelled")
+
+# How long one finalizer may hold the claim before another may take over
+# (crash recovery: the sweep can re-finalize after the lease expires).
+_FINALIZE_LEASE = timedelta(minutes=10)
+
+
+def _falclient_status_code(error: Exception):
+    """HTTP status from a FalClientError (raised `from httpx.HTTPStatusError`)."""
+    cause = getattr(error, "__cause__", None)
+    resp = getattr(cause, "response", None)
+    code = getattr(resp, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
 def fal_update_task(task: Task, status: str, payload, error):
     """Finalize a fal task from a webhook payload ({status: OK|ERROR, payload})
     or from a status poll (async_wait / the periodic sweep).
 
-    IDEMPOTENT via the terminal-status guard: fal retries webhook deliveries,
-    and the sweep or a blocking waiter can race a webhook — only the first
-    finalizer runs; the rest no-op. Mirrors replicate_update_task.
+    Finalizers RACE each other by design — fal retries webhook deliveries (its
+    delivery timeout is short relative to a video upload), a blocking
+    async_wait polls at 1s, and the sweep re-polls stragglers. So the first
+    step is an ATOMIC CLAIM on the task document (status not terminal AND no
+    live finalize lease); losers no-op. A crashed finalizer's lease expires
+    after _FINALIZE_LEASE, letting the sweep retry. Mirrors
+    replicate_update_task for the actual output handling.
     """
-    task.reload()
-    if task.status in ("completed", "failed", "cancelled"):
+    tasks = get_collection("tasks3")
+    now = datetime.now(timezone.utc)
+    claimed = tasks.find_one_and_update(
+        {
+            "_id": task.id,
+            "status": {"$nin": list(TERMINAL_STATES)},
+            "$or": [
+                {"finalizing_at": None},
+                {"finalizing_at": {"$lt": now - _FINALIZE_LEASE}},
+            ],
+        },
+        {"$set": {"finalizing_at": now}},
+    )
+    if claimed is None:
+        # Terminal already, or another finalizer holds the claim.
+        task.reload()
         return {"status": task.status}
 
     if status != "OK":
@@ -475,6 +425,16 @@ def fal_update_task(task: Task, status: str, payload, error):
 
     tool = Tool.load(task.tool)
     urls = tool._extract_urls_from_fal_result(payload or {})
+    if not urls and task.handler_id:
+        # fal delivers status "OK" with payload null (+ payload_error) when the
+        # response wasn't serializable/deliverable inline — the run SUCCEEDED
+        # and the docs say to fetch the result from the queue instead. Failing
+        # here would refund a job fal charged us for.
+        try:
+            fetched = fal_client.result(tool.fal_endpoint, task.handler_id)
+            urls = tool._extract_urls_from_fal_result(fetched or {})
+        except Exception as e:
+            logger.warning(f"fal result fallback fetch failed for {task.id}: {e}")
     if not urls:
         error_msg = f"fal returned no output: {str(payload)[:300]}"
         task.update(status="failed", error=error_msg)
@@ -502,10 +462,36 @@ def fal_update_task(task: Task, status: str, payload, error):
     run_time = (
         datetime.now(timezone.utc) - task.createdAt.replace(tzinfo=timezone.utc)
     ).total_seconds()
-    task.performance["runTime"] = run_time
+    if task.performance.get("waitTime"):
+        run_time -= task.performance["waitTime"]
+    performance = {**(task.performance or {}), "runTime": run_time}
+
+    # Conditional terminal write (NOT a full-document save): if the user
+    # cancelled during the upload window, handle_cancel already refunded —
+    # stomping status back to completed would let them keep both the manna
+    # and the output. Losing this write is the correct outcome then.
+    finished = tasks.find_one_and_update(
+        {"_id": task.id, "status": {"$nin": list(TERMINAL_STATES)}},
+        {
+            "$set": {
+                "status": "completed",
+                "result": result,
+                "performance": performance,
+            },
+            "$unset": {"finalizing_at": ""},
+        },
+    )
+    if finished is None:
+        task.reload()
+        logger.warning(
+            f"fal task {task.id} reached terminal state ({task.status}) during "
+            "finalization; completed result discarded"
+        )
+        return {"status": task.status}
+
     task.status = "completed"
     task.result = result
-    task.save()
+    task.performance = performance
     return {"status": "completed", "result": result}
 
 
@@ -522,34 +508,56 @@ def fal_update_task(task: Task, status: str, payload, error):
 
 FAL_JWKS_URL = "https://rest.alpha.fal.ai/.well-known/jwks.json"
 _FAL_JWKS_TTL = 24 * 3600  # fal say keys may rotate; don't cache longer than 24h
-_fal_jwks_cache = {"keys": None, "fetched_at": 0.0}
+_fal_jwks_cache = {"keys": None, "fetched_at": 0.0, "failed_at": 0.0}
+_FAL_JWKS_NEGATIVE_TTL = 60  # after a failed fetch, don't re-fetch for this long
 
 
 def _get_fal_public_keys():
+    """fal's ED25519 public keys, cached.
+
+    Resilience matters here because this endpoint is unauthenticated: an
+    attacker flooding garbage requests must not be able to turn every request
+    into an outbound JWKS fetch. Failures are negative-cached briefly, and a
+    stale key set is served rather than failing verification outright (fal say
+    keys can rotate, so we never cache success longer than _FAL_JWKS_TTL).
+    """
     import base64
     import time
 
     import httpx
 
     now = time.time()
-    if (
-        _fal_jwks_cache["keys"]
-        and now - _fal_jwks_cache["fetched_at"] < _FAL_JWKS_TTL
-    ):
-        return _fal_jwks_cache["keys"]
+    cache = _fal_jwks_cache
+    if cache["keys"] and now - cache["fetched_at"] < _FAL_JWKS_TTL:
+        return cache["keys"]
 
-    resp = httpx.get(FAL_JWKS_URL, timeout=10)
-    resp.raise_for_status()
-    keys = []
-    for jwk in resp.json().get("keys", []):
-        x = jwk.get("x")
-        if not x:
-            continue
-        pad = "=" * (-len(x) % 4)
-        keys.append(base64.urlsafe_b64decode(x + pad))
-    if keys:
-        _fal_jwks_cache.update(keys=keys, fetched_at=now)
-    return keys
+    # Within the negative-cache window: serve stale keys if we have them,
+    # otherwise fail fast without another outbound request.
+    if now - cache["failed_at"] < _FAL_JWKS_NEGATIVE_TTL:
+        if cache["keys"]:
+            return cache["keys"]
+        raise ValueError("fal JWKS unavailable (recent fetch failed)")
+
+    try:
+        resp = httpx.get(FAL_JWKS_URL, timeout=10)
+        resp.raise_for_status()
+        keys = []
+        for jwk in resp.json().get("keys", []):
+            x = jwk.get("x")
+            if not x:
+                continue
+            pad = "=" * (-len(x) % 4)
+            keys.append(base64.urlsafe_b64decode(x + pad))
+        if not keys:
+            raise ValueError("fal JWKS contained no usable keys")
+        cache.update(keys=keys, fetched_at=now)
+        return keys
+    except Exception:
+        cache["failed_at"] = now
+        if cache["keys"]:
+            # Expired-but-present keys beat dropping a legitimate delivery.
+            return cache["keys"]
+        raise
 
 
 def verify_fal_webhook(body: bytes, headers) -> None:
@@ -573,10 +581,21 @@ def verify_fal_webhook(body: bytes, headers) -> None:
 
     try:
         skew = abs(time.time() - int(timestamp))
-    except ValueError:
+    except (ValueError, OverflowError):
+        # int() raises ValueError on garbage; the subtraction can raise
+        # OverflowError on an absurdly large integer. Both are forgeries.
         raise ValueError("invalid timestamp header")
     if skew > 300:
         raise ValueError(f"timestamp outside tolerance ({skew:.0f}s)")
+
+    # A valid fal signature proves "fal signed this", not "this is OUR
+    # webhook" — any fal customer can point their own job at our URL and fal
+    # will happily sign the delivery. When FAL_WEBHOOK_USER_ID is set, bind
+    # deliveries to our account (checked before the JWKS fetch so foreign
+    # traffic can't trigger outbound requests).
+    expected_user = os.getenv("FAL_WEBHOOK_USER_ID")
+    if expected_user and user_id != expected_user:
+        raise ValueError("webhook user id does not match this account")
 
     message = "\n".join(
         [request_id, user_id, timestamp, hashlib.sha256(body).hexdigest()]

--- a/tests/test_fal_webhook.py
+++ b/tests/test_fal_webhook.py
@@ -3,11 +3,12 @@
 The verification recipe (message = request_id\nuser_id\ntimestamp\n
 sha256_hex(body), ED25519 against JWKS keys, +/-5 min tolerance) matches fal's
 documented scheme; these tests prove our implementation of it with a real
-keypair, and prove fal_update_task's status mapping and idempotency.
+keypair, and prove fal_update_task's claim/status mapping and idempotency.
 """
 
 import hashlib
 import time
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,17 +17,17 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from eve.tools import fal_tool
 from eve.tools.fal_tool import fal_update_task, verify_fal_webhook
 
-
 # ---------------------------------------------------------------------------
 # signature verification
 # ---------------------------------------------------------------------------
 
-def _signed_request(body: bytes, ts_offset: int = 0):
+
+def _signed_request(body: bytes, ts_offset: int = 0, ts_raw: str = None,
+                    user_id: str = "user-456"):
     key = Ed25519PrivateKey.generate()
     pub = key.public_key().public_bytes_raw()
     request_id = "req-123"
-    user_id = "user-456"
-    timestamp = str(int(time.time()) + ts_offset)
+    timestamp = ts_raw if ts_raw is not None else str(int(time.time()) + ts_offset)
     message = "\n".join(
         [request_id, user_id, timestamp, hashlib.sha256(body).hexdigest()]
     ).encode()
@@ -63,6 +64,16 @@ def test_stale_timestamp_rejected():
             verify_fal_webhook(body, headers)
 
 
+def test_absurd_timestamp_rejected_not_500():
+    """A 400-digit timestamp must raise the controlled ValueError, not
+    OverflowError escaping to the route."""
+    body = b"{}"
+    headers, pub = _signed_request(body, ts_raw="9" * 400)
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        with pytest.raises(ValueError, match="invalid timestamp"):
+            verify_fal_webhook(body, headers)
+
+
 def test_wrong_key_rejected():
     body = b"{}"
     headers, _ = _signed_request(body)
@@ -81,36 +92,83 @@ def test_missing_header_rejected():
             verify_fal_webhook(body, headers)
 
 
+def test_user_id_pinning(monkeypatch):
+    """With FAL_WEBHOOK_USER_ID set, deliveries signed for OTHER fal accounts
+    are rejected before any JWKS fetch; our own pass."""
+    body = b"{}"
+    headers, pub = _signed_request(body, user_id="attacker-account")
+    monkeypatch.setenv("FAL_WEBHOOK_USER_ID", "our-account")
+    fetched = MagicMock(side_effect=AssertionError("JWKS must not be fetched"))
+    with patch.object(fal_tool, "_get_fal_public_keys", fetched):
+        with pytest.raises(ValueError, match="does not match"):
+            verify_fal_webhook(body, headers)
+
+    headers, pub = _signed_request(body, user_id="our-account")
+    with patch.object(fal_tool, "_get_fal_public_keys", return_value=[pub]):
+        verify_fal_webhook(body, headers)  # should not raise
+
+
+def test_jwks_stale_served_on_fetch_failure(monkeypatch):
+    """An expired-but-present key set is served when the JWKS fetch fails, so a
+    fal blip doesn't drop legitimate deliveries."""
+    import httpx
+
+    stale_keys = [b"k" * 32]
+    monkeypatch.setattr(
+        fal_tool,
+        "_fal_jwks_cache",
+        {"keys": stale_keys, "fetched_at": 0.0, "failed_at": 0.0},
+    )
+    with patch.object(httpx, "get", side_effect=httpx.ConnectError("down")):
+        assert fal_tool._get_fal_public_keys() == stale_keys
+    # and the failure is negative-cached
+    assert fal_tool._fal_jwks_cache["failed_at"] > 0
+
+
 # ---------------------------------------------------------------------------
 # fal_update_task
 # ---------------------------------------------------------------------------
+
 
 def _task(status="pending"):
     task = MagicMock()
     task.status = status
     task.args = {"prompt": "a cat"}
     task.performance = {}
+    task.handler_id = "req-1"
+    task.createdAt = datetime.now(timezone.utc) - timedelta(seconds=30)
     task.reload = MagicMock()
     return task
 
 
+def _collection(claim=True, finish=True):
+    """Mock tasks3: first find_one_and_update = claim, second = terminal write."""
+    col = MagicMock()
+    col.find_one_and_update.side_effect = [
+        {"_id": "t"} if claim else None,
+        {"_id": "t"} if finish else None,
+    ]
+    return col
+
+
 def test_error_payload_fails_task_and_refunds():
     task = _task()
-    out = fal_update_task(task, "ERROR", None, "Invalid status code: 422")
+    with patch.object(fal_tool, "get_collection", return_value=_collection()):
+        out = fal_update_task(task, "ERROR", None, "Invalid status code: 422")
     assert out["status"] == "failed"
-    task.update.assert_called_once()
     assert task.update.call_args.kwargs["status"] == "failed"
     task.refund_manna.assert_called_once()
 
 
-def test_idempotent_when_terminal():
-    """fal retries webhook deliveries; a second delivery must no-op."""
-    for terminal in ("completed", "failed", "cancelled"):
-        task = _task(status=terminal)
+def test_claim_lost_is_noop():
+    """fal retries deliveries and pollers race the webhook; whoever loses the
+    atomic claim must do nothing."""
+    task = _task()
+    with patch.object(fal_tool, "get_collection", return_value=_collection(claim=False)):
         out = fal_update_task(task, "OK", {"video": {"url": "http://x"}}, None)
-        assert out["status"] == terminal
-        task.update.assert_not_called()
-        task.refund_manna.assert_not_called()
+    assert out["status"] == task.status
+    task.update.assert_not_called()
+    task.refund_manna.assert_not_called()
 
 
 def test_ok_payload_completes_with_creation():
@@ -118,24 +176,72 @@ def test_ok_payload_completes_with_creation():
     tool = MagicMock()
     tool._extract_urls_from_fal_result.return_value = ["https://fal/video.mp4"]
     uploaded = [{"filename": "abc.mp4", "mediaAttributes": {"duration": 3}}]
-    with patch.object(fal_tool.Tool, "load", return_value=tool), \
+    col = _collection()
+    with patch.object(fal_tool, "get_collection", return_value=col), \
+         patch.object(fal_tool.Tool, "load", return_value=tool), \
          patch.object(fal_tool.utils, "upload_result", return_value=uploaded), \
          patch.object(fal_tool, "Creation") as MockCreation:
         MockCreation.return_value.id = "creation-id"
         out = fal_update_task(task, "OK", {"video": {"url": "https://fal/video.mp4"}}, None)
     assert out["status"] == "completed"
-    assert task.status == "completed"
     assert task.result[0]["output"][0]["creation"] == "creation-id"
     MockCreation.return_value.save.assert_called_once()
-    task.save.assert_called()
+    # terminal write is conditional, not a full-doc save
+    terminal_set = col.find_one_and_update.call_args_list[1].args[1]["$set"]
+    assert terminal_set["status"] == "completed"
+    assert terminal_set["performance"]["runTime"] > 0
+    task.refund_manna.assert_not_called()
+
+
+def test_cancelled_mid_finalization_not_stomped():
+    """User cancels (and is refunded) while the upload runs: the completed
+    result must be DISCARDED, not written over the cancellation."""
+    task = _task()
+    tool = MagicMock()
+    tool._extract_urls_from_fal_result.return_value = ["https://fal/v.mp4"]
+    uploaded = [{"filename": "a.mp4", "mediaAttributes": {}}]
+    with patch.object(fal_tool, "get_collection",
+                      return_value=_collection(finish=False)), \
+         patch.object(fal_tool.Tool, "load", return_value=tool), \
+         patch.object(fal_tool.utils, "upload_result", return_value=uploaded), \
+         patch.object(fal_tool, "Creation") as MockCreation:
+        MockCreation.return_value.id = "c"
+        task.reload = MagicMock(side_effect=lambda: setattr(task, "status", "cancelled"))
+        out = fal_update_task(task, "OK", {"video": {"url": "https://fal/v.mp4"}}, None)
+    assert out["status"] == "cancelled"
+
+
+def test_ok_with_null_payload_falls_back_to_result_fetch():
+    """fal sends status OK + payload null when the result wasn't deliverable
+    inline; the run SUCCEEDED and must not be failed+refunded."""
+    task = _task()
+    tool = MagicMock()
+    tool.fal_endpoint = "fal-ai/some/endpoint"
+    tool._extract_urls_from_fal_result.side_effect = [
+        [],  # from the null payload
+        ["https://fal/fetched.mp4"],  # from the queue result fetch
+    ]
+    uploaded = [{"filename": "f.mp4", "mediaAttributes": {}}]
+    with patch.object(fal_tool, "get_collection", return_value=_collection()), \
+         patch.object(fal_tool.Tool, "load", return_value=tool), \
+         patch.object(fal_tool.fal_client, "result", return_value={"video": {}}) as res, \
+         patch.object(fal_tool.utils, "upload_result", return_value=uploaded), \
+         patch.object(fal_tool, "Creation") as MockCreation:
+        MockCreation.return_value.id = "c"
+        out = fal_update_task(task, "OK", None, None)
+    res.assert_called_once_with("fal-ai/some/endpoint", "req-1")
+    assert out["status"] == "completed"
     task.refund_manna.assert_not_called()
 
 
 def test_empty_result_fails_and_refunds():
     task = _task()
     tool = MagicMock()
+    tool.fal_endpoint = "fal-ai/some/endpoint"
     tool._extract_urls_from_fal_result.return_value = []
-    with patch.object(fal_tool.Tool, "load", return_value=tool):
+    with patch.object(fal_tool, "get_collection", return_value=_collection()), \
+         patch.object(fal_tool.Tool, "load", return_value=tool), \
+         patch.object(fal_tool.fal_client, "result", side_effect=Exception("422")):
         out = fal_update_task(task, "OK", {}, None)
     assert out["status"] == "failed"
     task.refund_manna.assert_called_once()


### PR DESCRIPTION
Same race as #566→#567: the `/finish` hardening commit (`419da6d4`) was pushed minutes after #567 merged. Prod currently runs the v2 webhook architecture **without** it — verifiable live: `POST /update-fal` with garbage returns 200 today; with this commit it returns 401.

This is exactly one commit, containing **real bug fixes**, not just polish:

1. **Failed-job recovery was dead code** — fal has no FAILED queue status (verified in fal_client source); failed jobs report COMPLETED and surface as a 4xx on the result fetch. Without this, a failed job with a missed webhook sits 3h and never refunds via polling.
2. **Atomic finalization claim** — agent-session polling races the webhook within ~1s; without the claim, duplicate Creation docs are near-guaranteed for agent fal tasks.
3. **Cancel-during-upload no longer stomped** back to completed (user kept refund + output).
4. **`status:OK, payload:null`** no longer fails+refunds a succeeded, billed job.
5. Event-loop protection (verification + finalization threaded), sweep starvation fix, 401/404/400 endpoint semantics, Mongo-operator guard, optional `FAL_WEBHOOK_USER_ID` pinning, JWKS resilience, ~100 lines dead code removed.

57 tests pass · TestClient e2e all four response paths · dispatch sweep clean. Full detail in the [#567 comment](https://github.com/edenartlab/eve/pull/567#issuecomment-5135550487).

**After merge**: `POST /update-fal` garbage → 401 confirms it's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)