### PR TITLE
Fix: LoRA generations billed pro tier for output pro cannot change

### DIFF
--- a/eve/agent/generation.py
+++ b/eve/agent/generation.py
@@ -234,6 +234,16 @@ def pro_tier_is_noop(args: dict, access: GenerationAccess) -> bool:
             return not access.premium_enabled
         return False
 
+    # LoRA generations pick their model by the LoRA's BASE MODEL, not by tier:
+    # create routes them to txt2img (sdxl) or flux_dev_lora (flux), neither of
+    # which takes a quality-dependent argument. So pro changes nothing about
+    # the output while tripling the price — regardless of entitlement, which
+    # is why this check comes before the entitlement one below. (Only applies
+    # to generation: with a reference image the edit map is used instead and
+    # the LoRA is ignored.)
+    if args.get("lora") and not (args.get("reference_images") or []):
+        return True
+
     # Images: pro reaches gpt_image_2 with premium, or nano_banana_pro for
     # subscribers. With neither, it lands back on nano_banana_2_fal — the exact
     # standard-tier model, at 3x the price.

--- a/tests/test_pro_tier_billing.py
+++ b/tests/test_pro_tier_billing.py
@@ -85,3 +85,49 @@ def test_downgrade_actually_changes_the_bill():
     assert pro == 850 and std == 250
     # an unentitled img2vid caller is billed 250, not 850, for the kling_v3 they get
     assert pro_tier_is_noop({**I2V, "duration": 10}, acc()) is True
+
+
+# ---------------------------------------------------------------------------
+# LoRA generations: create routes by the LoRA's base model, ignoring quality
+# ---------------------------------------------------------------------------
+
+LORA_IMG = {"output": "image", "quality": "pro", "lora": "65f0…"}
+
+
+@pytest.mark.parametrize(
+    "args,access,expected,why",
+    [
+        (LORA_IMG, acc(), True, "sdxl/flux lora -> txt2img|flux_dev_lora, no quality arg"),
+        (LORA_IMG, acc(subscriber=True), True, "subscribers too — routing ignores tier"),
+        (LORA_IMG, acc(premium=True), True, "premium too — the lora branch precedes it"),
+        (
+            {**LORA_IMG, "reference_images": ["a.png"]},
+            acc(premium=True), False,
+            "with a reference image the edit map runs and the lora is ignored",
+        ),
+        (
+            {**LORA_IMG, "quality": "standard"},
+            acc(), False, "standard is never touched",
+        ),
+    ],
+)
+def test_lora_pro_is_noop(args, access, expected, why):
+    assert pro_tier_is_noop(args, access) is expected, why
+
+
+def test_lora_pro_bills_standard_not_3x():
+    """The overcharge in numbers: a pro LoRA image billed 30/sample for output
+    identical to the 10/sample standard render."""
+    from eve.utils.cost_utils import eval_cost
+
+    expr = (
+        '(output == "video" ? (((quality == "pro" ? 85 : 25) + '
+        '(sound_effects ? 10 : 0)) * duration) : '
+        '((quality == "pro" ? 30 : 10) * n_samples))'
+    )
+    pro = eval_cost(expr, output="image", quality="pro", sound_effects=None,
+                    duration=10, n_samples=1)
+    std = eval_cost(expr, output="image", quality="standard", sound_effects=None,
+                    duration=10, n_samples=1)
+    assert (pro, std) == (30, 10)
+    assert pro_tier_is_noop(LORA_IMG, acc(subscriber=True)) is True


### PR DESCRIPTION
A customer flagged their SDXL LoRA renders getting expensive. Two causes; **this PR fixes the one that's a bug.**

`create` picks the model for a LoRA generation by the LoRA's **base model**, not by tier:

```python
if loras:
    image_tool = "txt2img" if loras[0].base_model == "sdxl" else "flux_dev_lora"
```

Neither takes a quality-dependent argument — so `quality="pro"` yields a **byte-identical render at 30 manna/sample instead of 10**. A flat 3x overcharge, hitting LoRA power users specifically. **582 tasks** have taken this path.

`pro_tier_is_noop` missed it because it reasoned only about *entitlement* (a subscriber "deserves" pro → bill pro) and never about the LoRA override that makes the tier irrelevant **regardless** of entitlement. The new check precedes the entitlement one, and applies only to generation — with a reference image the edit map runs and the LoRA is ignored, where the tier does still matter.

**Effect: 30 → 10 manna/sample** for any pro LoRA image, with zero change to output.

Tests: 5-case matrix (sdxl/flux lora · subscriber · premium · reference-image exception · standard untouched) plus an assertion of the real 30-vs-10 spread. 49 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)