### PR TITLE
fix(manna): charge before dispatch, guard negative amounts, refund to source bucket

### DIFF
--- a/eve/task.py
+++ b/eve/task.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Literal, Optional
 import sentry_sdk
 from bson import ObjectId
 from loguru import logger
+from pymongo.errors import DuplicateKeyError
 
 from . import utils
 from .mongo import Collection, Document
@@ -185,43 +186,78 @@ class Task(Document):
         if self.cost == 0:
             return
         manna = Manna.load(self.paying_user or self.user)
-        manna.spend(self.cost)
+        split = manna.spend(self.cost) or {}
         Transaction(
             manna=manna.id,
             task=self.id,
             amount=-self.cost,
             type="spend",
+            subscription_amount=split.get("subscription") or None,
         ).save()
 
+    def _count_delivered_outputs(self) -> int:
+        """Outputs the user actually received. `result` alone is not
+        trustworthy: cancellation clears it while the Creation docs saved
+        during the run persist — counting creations closes the
+        cancel-after-delivery full-refund exploit."""
+        delivered = len(self.result or [])
+        try:
+            creations = Creation.get_collection().count_documents({"task": self.id})
+            delivered = max(delivered, creations)
+        except Exception as e:
+            logger.warning(f"Could not count creations for task {self.id}: {e}")
+        return delivered
+
     def refund_manna(self):
-        n_samples = self.args.get("n_samples", 1)
-        refund_amount = (
-            (self.cost or 0) * (n_samples - len(self.result or [])) / n_samples
-        )
+        n_samples = max(int(self.args.get("n_samples") or 1), 1)
+        delivered = self._count_delivered_outputs()
+        undelivered_frac = max(n_samples - delivered, 0) / n_samples
+        refund_amount = (self.cost or 0) * undelivered_frac
 
         if refund_amount <= 0:
             return
 
         manna = Manna.load(self.paying_user or self.user)
 
+        # Restore the same buckets the spend came from, pro-rated by the
+        # refund fraction. Legacy spends without a recorded split refund to
+        # `balance` (old behavior).
+        refund_sub = 0.0
+        try:
+            spend_txn = Transaction.get_collection().find_one(
+                {"task": self.id, "type": "spend"}
+            )
+            if spend_txn and spend_txn.get("subscription_amount"):
+                refund_sub = float(spend_txn["subscription_amount"]) * undelivered_frac
+        except Exception as e:
+            logger.warning(f"Could not read spend split for task {self.id}: {e}")
+
         # Atomically insert the refund transaction only if one doesn't already
         # exist for this task.  The upsert filter {task, type} acts as a
         # de-duplication key: if a concurrent request already created the
         # refund document, upserted_id will be None (matched, not inserted).
+        # NOTE: this upsert is only race-proof because of the UNIQUE index on
+        # {task, type} (see Transaction.ensure_unique_refund_index) — without
+        # it two concurrent upserts can both insert and double-refund.
         txn_collection = Transaction.get_collection()
-        result = txn_collection.update_one(
-            {"task": self.id, "type": "refund"},
-            {
-                "$setOnInsert": {
-                    "manna": manna.id,
-                    "task": self.id,
-                    "amount": refund_amount,
-                    "type": "refund",
-                    "createdAt": datetime.now(timezone.utc),
-                }
-            },
-            upsert=True,
-        )
+        try:
+            result = txn_collection.update_one(
+                {"task": self.id, "type": "refund"},
+                {
+                    "$setOnInsert": {
+                        "manna": manna.id,
+                        "task": self.id,
+                        "amount": refund_amount,
+                        "type": "refund",
+                        "subscription_amount": refund_sub or None,
+                        "createdAt": datetime.now(timezone.utc),
+                    }
+                },
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            logger.warning(f"Refund already issued for task {self.id} (index)")
+            return
 
         if result.upserted_id is None:
             # The document already existed -- another path already refunded
@@ -229,7 +265,7 @@ class Task(Document):
             return
 
         # Only credit the balance if *we* won the insert race
-        manna.refund(refund_amount)
+        manna.refund(refund_amount, subscription_amount=refund_sub)
 
 
 def task_handler_func(func):

--- a/eve/tool.py
+++ b/eve/tool.py
@@ -552,7 +552,10 @@ class Tool(Document, ABC):
         cost_estimate = utils.eval_cost(
             self.cost_estimate, **self.prepare_args(args.copy())
         )
-        return cost_estimate
+        # Never negative: a bad expression or unbounded numeric arg could
+        # otherwise drive cost below zero, which downstream would credit
+        # rather than charge.
+        return max(cost_estimate or 0, 0)
 
     def prepare_args(self, args: dict):
         # Resolve parameter aliases (e.g., session_id -> session)
@@ -771,6 +774,18 @@ class Tool(Document, ABC):
                 category="handle_start_task", data=task.model_dump()
             )
 
+            # Charge BEFORE submitting to Modal: the old order (submit, then
+            # spend) let a job run for free when the spend failed — e.g. two
+            # near-simultaneous tasks against a balance that only covers one
+            # both passed the read-only check_manna and both got submitted.
+            # if "free_tools" not in (paying_user.featureFlags or []):
+            if True:
+                try:
+                    task.spend_manna()
+                except Exception as e:
+                    task.update(status="failed", error=str(e))
+                    raise Exception(f"Task failed: {e}. No manna deducted.")
+
             # start task
             try:
                 if mock:
@@ -796,15 +811,20 @@ class Tool(Document, ABC):
                     if not pre_handler_id:
                         task.update(handler_id=handler_id)
 
-                # if "free_tools" not in (paying_user.featureFlags or []):
-                if True:
-                    task.spend_manna()
-
             except Exception as e:
                 logger.error(traceback.format_exc())
                 task.update(status="failed", error=str(e))
+                # Submission failed after payment — give the manna back.
+                try:
+                    task.refund_manna()
+                except Exception as refund_err:
+                    logger.error(
+                        f"Refund after failed submission also failed for task "
+                        f"{task.id}: {refund_err}"
+                    )
+                    sentry_sdk.capture_exception(refund_err)
                 sentry_sdk.capture_exception(e)
-                raise Exception(f"Task failed: {e}. No manna deducted.")
+                raise Exception(f"Task failed: {e}. Manna refunded.")
 
             return task
 
@@ -841,6 +861,21 @@ class Tool(Document, ABC):
                 if force:
                     # Forced cancellation from the server due to stuck task
                     task.update(status="failed", error="Timed out")
+                    # The user was charged for work that timed out. The normal
+                    # cancel path refunds via the worker's finally block, but a
+                    # force-fail sets "failed" instead of "cancelled" so that
+                    # branch never runs — 50 tasks (~4,288 manna) in the last 60
+                    # days were charged and never refunded. refund_manna is
+                    # idempotent (unique {task,type} index) and prorates by
+                    # delivered creations, so a partially-delivered task refunds
+                    # only the undelivered share.
+                    try:
+                        task.refund_manna()
+                    except Exception as refund_err:
+                        logger.error(
+                            f"Failed to refund force-cancelled task {task.id}: {refund_err}"
+                        )
+                        sentry_sdk.capture_exception(refund_err)
                 else:
                     # Clear results so cancelled tasks never have usable output
                     task.update(status="cancelled", result=[])

--- a/eve/user.py
+++ b/eve/user.py
@@ -36,8 +36,19 @@ class Manna(Document):
             raise e
 
     def spend(self, amount: float):
+        """Deduct manna, drawing subscription balance first.
+
+        Returns {"subscription": x, "balance": y} — the split actually
+        debited — so callers can record it and refunds can restore the
+        same buckets.
+        """
         if amount == 0:
-            return
+            return {"subscription": 0.0, "balance": 0.0}
+        if amount < 0:
+            # A negative spend would pass the $gte guards below and CREDIT the
+            # balance — i.e. mint manna. Negative costs are always a bug
+            # upstream (bad cost_estimate or unvalidated args).
+            raise Exception(f"Invalid negative spend amount: {amount}")
         collection = self.get_collection()
 
         # Read current balances to determine the split between subscription and regular
@@ -73,14 +84,28 @@ class Manna(Document):
         # Update local state from the authoritative DB result
         self.subscriptionBalance = result.get("subscriptionBalance", 0)
         self.balance = result.get("balance", 0)
+        return {"subscription": subscription_spend, "balance": balance_spend}
 
-    def refund(self, amount: float):
+    def refund(self, amount: float, subscription_amount: float = 0.0):
+        """Credit manna back. `subscription_amount` (<= amount) is restored to
+        subscriptionBalance, the rest to balance — so refunds return manna to
+        the buckets it was debited from instead of converting expiring
+        subscription manna into permanent balance."""
         if amount == 0:
             return
+        if amount < 0:
+            # A negative refund is a hidden debit — never valid.
+            raise Exception(f"Invalid negative refund amount: {amount}")
+        subscription_amount = max(0.0, min(subscription_amount or 0.0, amount))
         collection = self.get_collection()
         result = collection.find_one_and_update(
             {"_id": self.id},
-            {"$inc": {"balance": amount}},
+            {
+                "$inc": {
+                    "balance": amount - subscription_amount,
+                    "subscriptionBalance": subscription_amount,
+                }
+            },
             return_document=True,
         )
         if not result:
@@ -96,6 +121,9 @@ class Transaction(Document):
     task: Optional[ObjectId] = None
     amount: float
     type: Literal["spend", "refund", "daily_topup_mars_college_26"]
+    # How much of a spend came out of subscriptionBalance (refunds use this
+    # to restore the same bucket). Absent on legacy docs -> assume balance.
+    subscription_amount: Optional[float] = None
 
 
 # todo: add more stats


### PR DESCRIPTION
Completes spend/refund hardening that was sitting **uncommitted in the working tree**. Production is running the old code — confirmed: 0 of 2,858 spend transactions in the last 7 days carry the `subscription_amount` field this change writes.

Every finding below was verified against the production database before fixing.

## 1. Free work, and minting — charge happened *after* dispatch
`handle_start_task` submitted the Modal job and only then called `spend_manna()`. When the spend failed — ordinarily two near-simultaneous tasks against a balance that covers only one, since `check_manna` is a read — the container ran anyway and delivered output for free. Worse: if such an uncharged task later failed, `refund_manna()` refunded a cost that was **never collected**.

Production, last 30 days:
- **17 completed tasks (572 manna, $5.72)** delivered with no spend recorded — 15 `create`, 2 `ffmpeg_multitool`
- **2 refunds totalling 400 manna ($4)** against tasks that were never charged — manna minted from nothing

Fix: charge first, refund if dispatch then fails.

## 2. Cancel-after-partial-delivery refunded in full
`refund_manna` prorated by `len(result)`, but cancelling clears `result` while the `Creation` documents written during the run persist. A user could take k of n samples, cancel, and get a full refund while keeping the output. Now counts persisted creations and takes the max.

## 3. Refunds returned manna to the wrong bucket
`spend()` drains `subscriptionBalance` first, but `refund()` credited `balance` only — quietly converting expiring subscription manna into permanent manna on every refund of a subscription-funded spend (**309 refunds in the last 30 days**). `spend()` now returns the split, `spend_manna` records it, and `refund_manna` restores the same buckets pro-rata. Legacy spends with no recorded split still refund to `balance`.

## 4. Force-cancelled stuck tasks were charged and never refunded
`cancel_stuck_tasks` calls `async_cancel(force=True)`, which sets `status="failed"` rather than `"cancelled"`, so the worker's refund branch never ran. **50 tasks (~4,288 manna, $42.88) in the last 60 days** were charged for timed-out work with no refund. This one is user-harm rather than platform loss. `refund_manna` is idempotent via the unique `{task,type}` index and prorates by delivered creations, so it's safe for partially-delivered tasks.

## Also
`calculate_cost` is clamped at `>= 0`, and negative spend/refund amounts are rejected outright (a negative amount passes the `$gte` guards and *credits* the balance). No active tool can currently produce one — I swept live `tools3` — so this is defense-in-depth against a careless `eve tool update`.

## Note on scope
The working tree also carries unrelated in-progress edits (discord handlers, several `api.yaml` prices, google tools) and what looks like a **separate billing fix in the LLM providers + session runtime** for streamed turns dropping `cost_usd`. Those are deliberately **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)