### PR TITLE
fix: never retry a paid generation after the provider accepted it

### DIFF
--- a/eve/tools/elevenlabs/handler.py
+++ b/eve/tools/elevenlabs/handler.py
@@ -102,7 +102,8 @@ async def handler(context: ToolContext):
 
         return await asyncio.to_thread(_generate)
 
-    response = await utils.async_exponential_backoff(
+    # Paid generation: retry only failures that never reached ElevenLabs.
+    response = await utils.async_retry_if_unbilled(
         generate_with_timestamps,
         max_attempts=3,
         initial_delay=1,

--- a/eve/tools/elevenlabs_dialogue/handler.py
+++ b/eve/tools/elevenlabs_dialogue/handler.py
@@ -126,7 +126,8 @@ async def handler(context: ToolContext):
 
         return await asyncio.to_thread(_generate)
 
-    response = await utils.async_exponential_backoff(
+    # Paid generation: retry only failures that never reached ElevenLabs.
+    response = await utils.async_retry_if_unbilled(
         generate_dialogue,
         max_attempts=3,
         initial_delay=1,

--- a/eve/tools/elevenlabs_fx/handler.py
+++ b/eve/tools/elevenlabs_fx/handler.py
@@ -35,7 +35,8 @@ async def handler(context: ToolContext):
 
         return await asyncio.to_thread(_generate)
 
-    audio_generator = await utils.async_exponential_backoff(
+    # Paid generation: retry only failures that never reached ElevenLabs.
+    audio_generator = await utils.async_retry_if_unbilled(
         generate_with_params, max_attempts=3, initial_delay=1
     )
 

--- a/eve/tools/elevenlabs_music/handler.py
+++ b/eve/tools/elevenlabs_music/handler.py
@@ -61,7 +61,8 @@ async def handler(context: ToolContext):
 
         return await asyncio.to_thread(_generate)
 
-    audio = await utils.async_exponential_backoff(
+    # Paid generation: retry only failures that never reached ElevenLabs.
+    audio = await utils.async_retry_if_unbilled(
         generate_music,
         max_attempts=3,
         initial_delay=1,

--- a/eve/tools/elevenlabs_speech/handler.py
+++ b/eve/tools/elevenlabs_speech/handler.py
@@ -258,6 +258,22 @@ async def handler(context: ToolContext):
     if not segments_input:
         raise ValueError("Must provide 'segments' array")
 
+    # Validate up front. `voice` and `text` are declared required on the
+    # segment item schema, but nested object properties inside an array aren't
+    # enforced by parameter validation, so a segment missing `voice` used to
+    # reach the generator and die on a bare KeyError: 'voice' — an opaque
+    # message an agent can't act on, raised three times over by the retry
+    # wrapper. Fail here instead, before anything is submitted.
+    for i, segment in enumerate(segments_input):
+        missing = [k for k in ("text", "voice") if not (segment or {}).get(k)]
+        if missing:
+            raise ValueError(
+                f"segments[{i}] is missing required field(s): {', '.join(missing)}. "
+                "Every segment needs both 'text' and 'voice' (a voice name, "
+                "description, or @agent_username — use elevenlabs_search_voices "
+                "to find valid voice names)."
+            )
+
     is_dialogue = len(segments_input) > 1
 
     async def generate_speech():
@@ -343,7 +359,8 @@ async def handler(context: ToolContext):
 
         return await asyncio.to_thread(_generate)
 
-    response = await utils.async_exponential_backoff(
+    # Paid generation: retry only failures that never reached ElevenLabs.
+    response = await utils.async_retry_if_unbilled(
         generate_speech,
         max_attempts=3,
         initial_delay=1,

--- a/eve/tools/fal/nano_banana_2_fal/handler.py
+++ b/eve/tools/fal/nano_banana_2_fal/handler.py
@@ -1,159 +1,17 @@
-import asyncio
 import os
 
-import fal_client
-import httpx
 from loguru import logger
 
 from eve.tool import ToolContext
+from eve.tools.fal_tool import call_fal
 
 # Endpoints for Nano Banana 2
 TXT2IMG_ENDPOINT = "fal-ai/nano-banana-2"
 IMG2IMG_ENDPOINT = "fal-ai/nano-banana-2/edit"
 
-# Retry configuration
-MAX_RETRIES = 3
-INITIAL_DELAY = 1.0
-
-
-def _fal_status_code(error: Exception):
-    """Best-effort extraction of the HTTP status code from a fal_client error.
-
-    fal_client raises ``FalClientError(detail) from httpx.HTTPStatusError`` (see
-    fal_client.client._raise_for_status), so the real status code lives on the
-    chained cause's response — NOT reliably in the stringified message. Relying on
-    digit-substring matching of the message misclassifies e.g. a 422 whose detail
-    contains a pixel size or byte count as a "5xx server error".
-    """
-    for candidate in (getattr(error, "__cause__", None), error):
-        resp = getattr(candidate, "response", None)
-        code = getattr(resp, "status_code", None)
-        if isinstance(code, int):
-            return code
-    return None
-
-
-def _fal_detail(error: Exception) -> str:
-    """The real fal error detail (FalClientError carries response.json()['detail'])."""
-    detail = str(error).strip()
-    if len(detail) > 500:
-        detail = detail[:500] + "…"
-    return detail
-
-
-def _is_retryable_error(error: Exception) -> bool:
-    """Determine if an error is retryable, preferring the real HTTP status code."""
-    code = _fal_status_code(error)
-    if code is not None:
-        # Rate limit / transient conflicts / server errors. 4xx validation
-        # errors (400/403/404/422 …) are NOT retryable — retrying wastes time
-        # and hides an actionable request problem.
-        return code in (408, 409, 429) or code >= 500
-
-    # No HTTP status (transport-level failure): treat network/timeouts as retryable.
-    error_str = str(error).lower()
-    return any(
-        term in error_str
-        for term in ["timeout", "connection", "network", "unavailable", "read error"]
-    )
-
-
-def _format_error_for_user(error: Exception) -> str:
-    """User-facing message that ALWAYS preserves fal's real status + detail.
-
-    Keeping the detail is the whole point: a 5xx with detail "Internal Server
-    Error" is a provider outage, but a 5xx/4xx whose detail is "failed to fetch
-    image_urls[1]" is our own bad input — previously both were flattened to an
-    identical opaque "FAL API server error", making outages indistinguishable
-    from request bugs.
-    """
-    code = _fal_status_code(error)
-    detail = _fal_detail(error)
-
-    # Provider content-policy rejections (e.g. ByteDance's reference-to-video
-    # partner validation rejects references that resemble real people — even
-    # photorealistic AI-generated humans). Surface actionable guidance instead
-    # of a bare 422 so an agent can adapt rather than assume an outage.
-    detail_l = detail.lower()
-    if "content_policy_violation" in detail_l or "likeness" in detail_l:
-        return (
-            "Rejected by the provider's content policy: input/reference media that "
-            "resembles a real person (or contains private information) can't be "
-            "processed. Use stylized, illustrated, or non-photorealistic references "
-            "— or a non-human subject — and retry. "
-            f"(provider detail: {detail})"
-        )
-
-    if code == 429:
-        return f"Rate limit reached (FAL 429). {detail} Try again shortly or use a different model."
-    if code in (401, 403):
-        return f"FAL access/authentication error ({code}): {detail}"
-    if code == 404:
-        return f"FAL endpoint not found (404): {detail}"
-    if code is not None and code >= 500:
-        return f"FAL server error ({code}): {detail}. Please try again later."
-    if code is not None:
-        # Other 4xx — surface the real validation detail so it's actionable.
-        return f"FAL rejected the request ({code}): {detail}"
-
-    # No HTTP status: transport-level failure.
-    if "timeout" in detail.lower():
-        return f"FAL request timed out: {detail}"
-    return detail or "FAL request failed."
-
-
-async def call_fal_with_retry(endpoint: str, args: dict) -> dict:
-    """
-    Call FAL API with exponential backoff retry logic.
-
-    Args:
-        endpoint: The FAL API endpoint
-        args: Arguments for the API call
-
-    Returns:
-        The API response dict
-
-    Raises:
-        ValueError: With user-friendly error message
-    """
-    delay = INITIAL_DELAY
-    last_error = None
-
-    for attempt in range(MAX_RETRIES + 1):
-        try:
-
-            def on_queue_update(update):
-                if isinstance(update, fal_client.InProgress):
-                    for log in update.logs:
-                        logger.info(log["message"])
-
-            result = await asyncio.to_thread(
-                fal_client.subscribe,
-                endpoint,
-                arguments=args,
-                with_logs=True,
-                on_queue_update=on_queue_update,
-            )
-            return result
-
-        except Exception as e:
-            last_error = e
-            logger.warning(
-                f"FAL API call failed (attempt {attempt + 1}/{MAX_RETRIES + 1}): {e}"
-            )
-
-            # Check if error is retryable and we have retries left
-            if _is_retryable_error(e) and attempt < MAX_RETRIES:
-                logger.info(f"Retrying in {delay}s...")
-                await asyncio.sleep(delay)
-                delay *= 2  # Exponential backoff
-                continue
-
-            # Non-retryable or max retries reached
-            raise ValueError(_format_error_for_user(e))
-
-    # Should not reach here, but just in case
-    raise ValueError(_format_error_for_user(last_error))
+# Canonical fal call: submit once, poll to completion, never resubmit.
+# Kept under the historical name because several fal tools import it from here.
+call_fal_with_retry = call_fal
 
 
 async def handler(context: ToolContext):
@@ -209,8 +67,8 @@ async def handler(context: ToolContext):
         # strict); provider default is "4". Overridable if the caller sets it.
         fal_args["safety_tolerance"] = str(args.get("safety_tolerance") or "6")
 
-    # Make the API call with retry logic
-    result = await call_fal_with_retry(endpoint, fal_args)
+    # One generation, one fal bill. No retry: see call_fal.
+    result = await call_fal(endpoint, fal_args)
 
     # Extract output URLs from result
     output_urls = []

--- a/eve/tools/fal/nano_banana_fal/handler.py
+++ b/eve/tools/fal/nano_banana_fal/handler.py
@@ -1,125 +1,13 @@
-import asyncio
 import os
 
-import fal_client
 from loguru import logger
 
 from eve.tool import ToolContext
+from eve.tools.fal_tool import call_fal
 
 # Endpoints for Nano Banana
 TXT2IMG_ENDPOINT = "fal-ai/nano-banana"
 IMG2IMG_ENDPOINT = "fal-ai/nano-banana/edit"
-
-# Retry configuration
-MAX_RETRIES = 3
-INITIAL_DELAY = 1.0
-
-
-def _is_retryable_error(error: Exception) -> bool:
-    """Determine if an error is retryable."""
-    error_str = str(error).lower()
-
-    # Rate limit errors (429)
-    if (
-        "429" in error_str
-        or "rate limit" in error_str
-        or "too many requests" in error_str
-    ):
-        return True
-
-    # Server errors (5xx)
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return True
-
-    # Network/timeout errors
-    if any(
-        term in error_str
-        for term in ["timeout", "connection", "network", "unavailable"]
-    ):
-        return True
-
-    return False
-
-
-def _format_error_for_user(error: Exception) -> str:
-    """Format error message for user-friendly display."""
-    error_str = str(error).lower()
-
-    if "429" in error_str or "rate limit" in error_str:
-        return "Rate limit reached for this image model. Please try again later or use a different image model."
-
-    if (
-        "401" in error_str
-        or "unauthorized" in error_str
-        or "authentication" in error_str
-    ):
-        return "Authentication error with FAL API. Please check API credentials."
-
-    if "403" in error_str or "forbidden" in error_str:
-        return "Access denied to FAL API. Please check API permissions."
-
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return "FAL API server error. Please try again later."
-
-    if "timeout" in error_str:
-        return "Request timed out. Please try again."
-
-    # Return original error for unknown cases
-    return str(error)
-
-
-async def call_fal_with_retry(endpoint: str, args: dict) -> dict:
-    """
-    Call FAL API with exponential backoff retry logic.
-
-    Args:
-        endpoint: The FAL API endpoint
-        args: Arguments for the API call
-
-    Returns:
-        The API response dict
-
-    Raises:
-        ValueError: With user-friendly error message
-    """
-    delay = INITIAL_DELAY
-    last_error = None
-
-    for attempt in range(MAX_RETRIES + 1):
-        try:
-
-            def on_queue_update(update):
-                if isinstance(update, fal_client.InProgress):
-                    for log in update.logs:
-                        logger.info(log["message"])
-
-            result = await asyncio.to_thread(
-                fal_client.subscribe,
-                endpoint,
-                arguments=args,
-                with_logs=True,
-                on_queue_update=on_queue_update,
-            )
-            return result
-
-        except Exception as e:
-            last_error = e
-            logger.warning(
-                f"FAL API call failed (attempt {attempt + 1}/{MAX_RETRIES + 1}): {e}"
-            )
-
-            # Check if error is retryable and we have retries left
-            if _is_retryable_error(e) and attempt < MAX_RETRIES:
-                logger.info(f"Retrying in {delay}s...")
-                await asyncio.sleep(delay)
-                delay *= 2  # Exponential backoff
-                continue
-
-            # Non-retryable or max retries reached
-            raise ValueError(_format_error_for_user(e))
-
-    # Should not reach here, but just in case
-    raise ValueError(_format_error_for_user(last_error))
 
 
 async def handler(context: ToolContext):
@@ -161,8 +49,8 @@ async def handler(context: ToolContext):
     if image_urls:
         fal_args["image_urls"] = image_urls
 
-    # Make the API call with retry logic
-    result = await call_fal_with_retry(endpoint, fal_args)
+    # One generation, one fal bill. No retry: see call_fal.
+    result = await call_fal(endpoint, fal_args)
 
     # Extract output URLs from result
     output_urls = []

--- a/eve/tools/fal/nano_banana_pro_fal/handler.py
+++ b/eve/tools/fal/nano_banana_pro_fal/handler.py
@@ -1,125 +1,13 @@
-import asyncio
 import os
 
-import fal_client
 from loguru import logger
 
 from eve.tool import ToolContext
+from eve.tools.fal_tool import call_fal
 
 # Endpoints for Nano Banana Pro
 TXT2IMG_ENDPOINT = "fal-ai/nano-banana-pro"
 IMG2IMG_ENDPOINT = "fal-ai/nano-banana-pro/edit"
-
-# Retry configuration
-MAX_RETRIES = 3
-INITIAL_DELAY = 1.0
-
-
-def _is_retryable_error(error: Exception) -> bool:
-    """Determine if an error is retryable."""
-    error_str = str(error).lower()
-
-    # Rate limit errors (429)
-    if (
-        "429" in error_str
-        or "rate limit" in error_str
-        or "too many requests" in error_str
-    ):
-        return True
-
-    # Server errors (5xx)
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return True
-
-    # Network/timeout errors
-    if any(
-        term in error_str
-        for term in ["timeout", "connection", "network", "unavailable"]
-    ):
-        return True
-
-    return False
-
-
-def _format_error_for_user(error: Exception) -> str:
-    """Format error message for user-friendly display."""
-    error_str = str(error).lower()
-
-    if "429" in error_str or "rate limit" in error_str:
-        return "Rate limit reached for this image model. Please try again later or use a different image model."
-
-    if (
-        "401" in error_str
-        or "unauthorized" in error_str
-        or "authentication" in error_str
-    ):
-        return "Authentication error with FAL API. Please check API credentials."
-
-    if "403" in error_str or "forbidden" in error_str:
-        return "Access denied to FAL API. Please check API permissions."
-
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return "FAL API server error. Please try again later."
-
-    if "timeout" in error_str:
-        return "Request timed out. Please try again."
-
-    # Return original error for unknown cases
-    return str(error)
-
-
-async def call_fal_with_retry(endpoint: str, args: dict) -> dict:
-    """
-    Call FAL API with exponential backoff retry logic.
-
-    Args:
-        endpoint: The FAL API endpoint
-        args: Arguments for the API call
-
-    Returns:
-        The API response dict
-
-    Raises:
-        ValueError: With user-friendly error message
-    """
-    delay = INITIAL_DELAY
-    last_error = None
-
-    for attempt in range(MAX_RETRIES + 1):
-        try:
-
-            def on_queue_update(update):
-                if isinstance(update, fal_client.InProgress):
-                    for log in update.logs:
-                        logger.info(log["message"])
-
-            result = await asyncio.to_thread(
-                fal_client.subscribe,
-                endpoint,
-                arguments=args,
-                with_logs=True,
-                on_queue_update=on_queue_update,
-            )
-            return result
-
-        except Exception as e:
-            last_error = e
-            logger.warning(
-                f"FAL API call failed (attempt {attempt + 1}/{MAX_RETRIES + 1}): {e}"
-            )
-
-            # Check if error is retryable and we have retries left
-            if _is_retryable_error(e) and attempt < MAX_RETRIES:
-                logger.info(f"Retrying in {delay}s...")
-                await asyncio.sleep(delay)
-                delay *= 2  # Exponential backoff
-                continue
-
-            # Non-retryable or max retries reached
-            raise ValueError(_format_error_for_user(e))
-
-    # Should not reach here, but just in case
-    raise ValueError(_format_error_for_user(last_error))
 
 
 async def handler(context: ToolContext):
@@ -168,8 +56,8 @@ async def handler(context: ToolContext):
     if image_urls:
         fal_args["image_urls"] = image_urls
 
-    # Make the API call with retry logic
-    result = await call_fal_with_retry(endpoint, fal_args)
+    # One generation, one fal bill. No retry: see call_fal.
+    result = await call_fal(endpoint, fal_args)
 
     # Extract output URLs from result
     output_urls = []

--- a/eve/tools/fal_tool.py
+++ b/eve/tools/fal_tool.py
@@ -30,62 +30,124 @@ def is_valid_url(value: Any) -> bool:
     return bool(url_pattern.match(value))
 
 
-# Retry configuration
-MAX_RETRIES = 3
-INITIAL_DELAY = 1.0
+def _falclient_status_code(error: Exception):
+    """HTTP status from a FalClientError (raised `from httpx.HTTPStatusError`).
+
+    fal_client raises ``FalClientError(detail) from httpx.HTTPStatusError`` (see
+    fal_client.client._raise_for_status), so the real status code lives on the
+    chained cause's response — NOT in the stringified message. Digit-substring
+    matching of the message misreads e.g. a 422 whose detail carries a pixel
+    size ("240x240"), a byte count, or a docs URL as a "5xx server error".
+    """
+    for candidate in (getattr(error, "__cause__", None), error):
+        resp = getattr(candidate, "response", None)
+        code = getattr(resp, "status_code", None)
+        if isinstance(code, int):
+            return code
+    return None
 
 
-def _is_retryable_error(error: Exception) -> bool:
-    """Determine if an error is retryable."""
-    error_str = str(error).lower()
-
-    # Rate limit errors (429)
-    if (
-        "429" in error_str
-        or "rate limit" in error_str
-        or "too many requests" in error_str
-    ):
-        return True
-
-    # Server errors (5xx)
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return True
-
-    # Network/timeout errors
-    if any(
-        term in error_str
-        for term in ["timeout", "connection", "network", "unavailable"]
-    ):
-        return True
-
-    return False
+def _fal_detail(error: Exception) -> str:
+    """The real fal error detail (FalClientError carries response.json()['detail'])."""
+    detail = str(error).strip()
+    if len(detail) > 500:
+        detail = detail[:500] + "\u2026"
+    return detail
 
 
 def _format_error_for_user(error: Exception) -> str:
-    """Format error message for user-friendly display."""
-    error_str = str(error).lower()
+    """User-facing message that ALWAYS preserves fal's real status + detail.
 
-    if "429" in error_str or "rate limit" in error_str:
-        return "Rate limit reached for this model. Please try again later or use a different model."
+    Keeping the detail is the whole point: a 5xx with detail "Internal Server
+    Error" is a provider outage, but a 4xx whose detail is "failed to fetch
+    image_urls[1]" is our own bad input — both used to be flattened into an
+    identical opaque "FAL API server error", making outages indistinguishable
+    from request bugs.
+    """
+    code = _falclient_status_code(error)
+    detail = _fal_detail(error)
 
-    if (
-        "401" in error_str
-        or "unauthorized" in error_str
-        or "authentication" in error_str
-    ):
-        return "Authentication error with FAL API. Please check API credentials."
+    # Provider content-policy rejections (e.g. reference media resembling a
+    # real person). Surface actionable guidance instead of a bare 422 so an
+    # agent can adapt rather than assume an outage.
+    detail_l = detail.lower()
+    if "content_policy_violation" in detail_l or "likeness" in detail_l:
+        return (
+            "Rejected by the provider's content policy: input/reference media that "
+            "resembles a real person (or contains private information) can't be "
+            "processed. Use stylized, illustrated, or non-photorealistic references "
+            "\u2014 or a non-human subject \u2014 and retry. "
+            f"(provider detail: {detail})"
+        )
 
-    if "403" in error_str or "forbidden" in error_str:
-        return "Access denied to FAL API. Please check API permissions."
+    if code == 429:
+        return f"Rate limit reached (FAL 429). {detail} Try again shortly or use a different model."
+    if code in (401, 403):
+        return f"FAL access/authentication error ({code}): {detail}"
+    if code == 404:
+        return f"FAL endpoint not found (404): {detail}"
+    if code is not None and code >= 500:
+        return f"FAL server error ({code}): {detail}. Please try again later."
+    if code is not None:
+        # Other 4xx — surface the real validation detail so it's actionable.
+        return f"FAL rejected the request ({code}): {detail}"
 
-    if any(f"{code}" in error_str for code in range(500, 600)):
-        return "FAL API server error. Please try again later."
+    # No HTTP status: transport-level failure.
+    if "timeout" in detail_l:
+        return f"FAL request timed out: {detail}"
+    return detail or "FAL request failed."
 
-    if "timeout" in error_str:
-        return "Request timed out. Please try again."
 
-    # Return original error for unknown cases
-    return str(error)
+def _drain(handle) -> dict:
+    """Stream logs for an already-accepted request, then fetch its result."""
+    for event in handle.iter_events(with_logs=True):
+        if isinstance(event, fal_client.InProgress):
+            for log in event.logs:
+                logger.info(log["message"])
+    return handle.get()
+
+
+async def call_fal(endpoint: str, args: dict, with_logs: bool = True) -> dict:
+    """Run exactly ONE fal generation, blocking until it finishes.
+
+    There is deliberately no generation-level retry. fal_client already retries
+    408/409/429/5xx internally on every HTTP request it makes, including the
+    submit POST (see fal_client.client._should_retry / MAX_RETRIES), so a
+    transient fal blip is absorbed *before* a job exists, for free.
+
+    The loop this replaces sat on top of that and re-entered
+    ``fal_client.subscribe`` — and subscribe SUBMITS. Every outer attempt minted
+    a fresh request_id, i.e. another billable generation charged against a
+    single manna spend (up to 4 fal jobs per task). It decided when to do that
+    by substring-matching str(e) for any number in 500..599, so a 422 whose
+    detail mentioned "240x240" or a docs URL was read as a server error and
+    re-billed three more times.
+
+    So: submit once, then poll. A submission that never landed raises and the
+    caller — the task handler, and above it the agent, which has context this
+    module does not — decides whether to spend again. A job fal has ACCEPTED is
+    never resubmitted; only its polls continue, and those are free, idempotent,
+    and already retried inside fal_client.
+    """
+    try:
+        handle = await asyncio.to_thread(fal_client.submit, endpoint, arguments=args)
+    except Exception as e:
+        # fal never accepted the request, so nothing was billed.
+        logger.warning(f"fal submit to {endpoint} failed: {e}")
+        raise ValueError(_format_error_for_user(e)) from e
+
+    # Past this line fal owns a billable job. Never resubmit it.
+    try:
+        return await asyncio.to_thread(_drain if with_logs else _get_quiet, handle)
+    except Exception as e:
+        logger.warning(
+            f"fal request {handle.request_id} ({endpoint}) failed after submission: {e}"
+        )
+        raise ValueError(_format_error_for_user(e)) from e
+
+
+def _get_quiet(handle) -> dict:
+    return handle.get()
 
 
 @tool_context("fal")
@@ -95,65 +157,16 @@ class FalTool(Tool):
         default=True, description="Whether to include logs in the response"
     )
 
-    async def _call_with_retry(self, endpoint: str, args: dict) -> dict:
-        """
-        Call FAL API with exponential backoff retry logic.
-
-        Args:
-            endpoint: The FAL API endpoint
-            args: Arguments for the API call
-
-        Returns:
-            The API response dict
-
-        Raises:
-            Exception: With user-friendly error message
-        """
-        delay = INITIAL_DELAY
-        last_error = None
-
-        for attempt in range(MAX_RETRIES + 1):
-            try:
-
-                def on_queue_update(update):
-                    if isinstance(update, fal_client.InProgress):
-                        for log in update.logs:
-                            logger.info(log["message"])
-
-                result = await asyncio.to_thread(
-                    fal_client.subscribe,
-                    endpoint,
-                    arguments=args,
-                    with_logs=self.with_logs,
-                    on_queue_update=on_queue_update if self.with_logs else None,
-                )
-                return result
-
-            except Exception as e:
-                last_error = e
-                logger.warning(
-                    f"FAL API call failed (attempt {attempt + 1}/{MAX_RETRIES + 1}): {e}"
-                )
-
-                # Check if error is retryable and we have retries left
-                if _is_retryable_error(e) and attempt < MAX_RETRIES:
-                    logger.info(f"Retrying in {delay}s...")
-                    await asyncio.sleep(delay)
-                    delay *= 2  # Exponential backoff
-                    continue
-
-                # Non-retryable or max retries reached
-                raise Exception(_format_error_for_user(e))
-
-        # Should not reach here, but just in case
-        raise Exception(_format_error_for_user(last_error))
+    async def _call_fal(self, endpoint: str, args: dict) -> dict:
+        """One fal generation, no generation-level retry. See call_fal."""
+        return await call_fal(endpoint, args, with_logs=self.with_logs)
 
     @Tool.handle_run
     async def async_run(self, context: ToolContext):
         check_fal_api_token()
         args = await asyncio.to_thread(self._format_args_for_fal, context.args)
 
-        result = await self._call_with_retry(self.fal_endpoint, args)
+        result = await self._call_fal(self.fal_endpoint, args)
 
         # Extract URLs from common FAL response structures (e.g., {"images": [{"url": "..."}]})
         output_urls = self._extract_urls_from_fal_result(result)
@@ -343,6 +356,7 @@ class FalTool(Tool):
 
         return new_args
 
+
 def get_webhook_url():
     env = {
         "PROD": "api-prod",
@@ -377,14 +391,6 @@ TERMINAL_STATES = ("completed", "failed", "cancelled")
 # How long one finalizer may hold the claim before another may take over
 # (crash recovery: the sweep can re-finalize after the lease expires).
 _FINALIZE_LEASE = timedelta(minutes=10)
-
-
-def _falclient_status_code(error: Exception):
-    """HTTP status from a FalClientError (raised `from httpx.HTTPStatusError`)."""
-    cause = getattr(error, "__cause__", None)
-    resp = getattr(cause, "response", None)
-    code = getattr(resp, "status_code", None)
-    return code if isinstance(code, int) else None
 
 
 def fal_update_task(task: Task, status: str, payload, error):

--- a/eve/tools/runway/handler.py
+++ b/eve/tools/runway/handler.py
@@ -3,12 +3,6 @@ import asyncio
 import runwayml
 from jinja2 import Template
 from runwayml import AsyncRunwayML
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 from eve.tool import ToolContext
 
@@ -100,14 +94,14 @@ async def handler(context: ToolContext):
     #         print(f"Error enhancing prompt: {e}")
     #         print("falling back to original prompt")
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=0, max=15),
-        retry=retry_if_exception_type(
-            (runwayml.APIConnectionError, runwayml.APIStatusError)
-        ),
-        retry_error_callback=lambda retry_state: retry_state.outcome.result(),
-    )
+    # Submitted exactly once — deliberately no retry wrapper. The runwayml SDK
+    # already retries connection errors and 408/409/429/5xx internally on the
+    # create POST (BaseClient._should_retry, DEFAULT_MAX_RETRIES=2), i.e. before
+    # a Runway task exists, for free. A retry layered on top of that re-issues
+    # the create call, which mints a NEW task id — a second paid generation
+    # against a single manna charge. The predicate it used made that worse:
+    # APIStatusError is the base class of every 4xx and 5xx, so a deterministic
+    # 400 counted as retryable.
     async def create_image_to_video():
         nonlocal unsafe_content_error
         try:

--- a/eve/tools/runway2/handler.py
+++ b/eve/tools/runway2/handler.py
@@ -4,12 +4,6 @@ import asyncio
 import runwayml
 from loguru import logger
 from runwayml import AsyncRunwayML
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 from eve.tool import ToolContext
 
@@ -18,14 +12,14 @@ async def handler(context: ToolContext):
     client = AsyncRunwayML()
     unsafe_content_error = False
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=0, max=15),
-        retry=retry_if_exception_type(
-            (runwayml.APIConnectionError, runwayml.APIStatusError)
-        ),
-        retry_error_callback=lambda retry_state: retry_state.outcome.result(),
-    )
+    # Submitted exactly once — deliberately no retry wrapper. The runwayml SDK
+    # already retries connection errors and 408/409/429/5xx internally on the
+    # create POST (BaseClient._should_retry, DEFAULT_MAX_RETRIES=2), i.e. before
+    # a Runway task exists, for free. A retry layered on top of that re-issues
+    # the create call, which mints a NEW task id — a second paid generation
+    # against a single manna charge. The predicate it used made that worse:
+    # APIStatusError is the base class of every 4xx and 5xx, so a deterministic
+    # 400 counted as retryable.
     async def create_image_to_video():
         nonlocal unsafe_content_error
         try:

--- a/eve/tools/runway3/handler.py
+++ b/eve/tools/runway3/handler.py
@@ -6,12 +6,6 @@ import asyncio
 import runwayml
 from loguru import logger
 from runwayml import AsyncRunwayML
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 from eve.tool import ToolContext
 
@@ -60,14 +54,14 @@ async def handler(context: ToolContext):
 
     ratio = _ratio_to_resolution(context.args.get("ratio", "16:9"))
 
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=0, max=15),
-        retry=retry_if_exception_type(
-            (runwayml.APIConnectionError, runwayml.APIStatusError)
-        ),
-        retry_error_callback=lambda retry_state: retry_state.outcome.result(),
-    )
+    # Submitted exactly once — deliberately no retry wrapper. The runwayml SDK
+    # already retries connection errors and 408/409/429/5xx internally on the
+    # create POST (BaseClient._should_retry, DEFAULT_MAX_RETRIES=2), i.e. before
+    # a Runway task exists, for free. A retry layered on top of that re-issues
+    # the create call, which mints a NEW task id — a second paid generation
+    # against a single manna charge. The predicate it used made that worse:
+    # APIStatusError is the base class of every 4xx and 5xx, so a deterministic
+    # 400 counted as retryable.
     async def create_video_to_video():
         nonlocal unsafe_content_error
         try:

--- a/eve/tools/tool_handlers.py
+++ b/eve/tools/tool_handlers.py
@@ -115,7 +115,7 @@ HANDLER_PATHS = {
 def _make_fal_handler(name):
     """Generic handler for any tool whose api.yaml declares a `fal_endpoint`.
 
-    Runs fal's blocking subscribe path (FalTool._call_with_retry) inside the
+    Runs fal's blocking submit-and-poll path (FalTool._call_fal) inside the
     Modal run_task container — the same approach the eve/tools/fal/* tools use
     and the only one proven to complete. Returns raw output URLs so the shared
     task handler does the uploading and Creation bookkeeping.
@@ -135,7 +135,7 @@ def _make_fal_handler(name):
 
         args = tool.prepare_args(dict(context.args))
         args = await asyncio.to_thread(tool._format_args_for_fal, args)
-        result = await tool._call_with_retry(endpoint, args)
+        result = await tool._call_fal(endpoint, args)
 
         urls = tool._extract_urls_from_fal_result(result)
         if not urls:

--- a/eve/utils/system_utils.py
+++ b/eve/utils/system_utils.py
@@ -112,6 +112,80 @@ async def async_exponential_backoff(
             delay = delay * 2
 
 
+def _http_status_code(error: Exception):
+    """HTTP status carried by an httpx error or a vendor SDK's ApiError."""
+    code = getattr(error, "status_code", None)
+    if isinstance(code, int):
+        return code
+    resp = getattr(error, "response", None)
+    code = getattr(resp, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
+def _is_provably_unbilled(error: Exception) -> bool:
+    """True only when the provider CANNOT have started (and billed) the work.
+
+    Deliberately conservative. The two cases that qualify:
+
+    * the request never left us — no connection was ever established, so the
+      provider never saw it;
+    * the provider answered 429 — it rejected the request outright instead of
+      generating anything.
+
+    Everything else is excluded on purpose, including 5xx and read timeouts:
+    those can fire *after* the provider has already generated (and charged
+    for) the audio, and only the delivery of the response failed. A 4xx other
+    than 429 is a deterministic request bug that would fail identically on
+    every attempt.
+    """
+    import httpx
+
+    if isinstance(error, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)):
+        return True
+    return _http_status_code(error) == 429
+
+
+async def async_retry_if_unbilled(
+    func,
+    max_attempts=3,
+    initial_delay=1,
+    max_jitter=1,
+):
+    """Backoff wrapper for calls that COST MONEY each time they reach the provider.
+
+    Same shape as async_exponential_backoff, but it retries only failures that
+    are provably unbilled (see _is_provably_unbilled) instead of catching bare
+    Exception. Retrying a paid generation on anything else buys the same output
+    two or three times against a single manna charge — the caller is charged
+    once, up front (Tool.handle_start_task), so extra provider attempts are
+    pure loss — and a deterministic 4xx (bad voice id, malformed input) is
+    re-billed on every attempt while never succeeding.
+
+    There is also no per-attempt asyncio timeout here, unlike
+    async_exponential_backoff. Its `asyncio.wait_for` cannot cancel the thread
+    running the HTTP request, so a slow generation (music allows 600s, but the
+    wrapper gave up at 300s) was abandoned mid-flight and re-issued while the
+    provider was still generating and billing the first one. The per-request
+    httpx timeouts already bound each attempt.
+
+    Use async_exponential_backoff for work that is free or idempotent to repeat.
+    """
+    delay = initial_delay
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await func()
+        except Exception as e:
+            if attempt == max_attempts or not _is_provably_unbilled(e):
+                raise
+            jitter = random.uniform(-max_jitter, max_jitter)
+            logger.warning(
+                f"Attempt {attempt} failed before the provider billed it ({e}). "
+                f"Retrying in {delay} seconds..."
+            )
+            await asyncio.sleep(delay + jitter)
+            delay = delay * 2
+
+
 def process_in_parallel(array, func, max_workers=3):
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {

--- a/tests/test_fal_no_double_billing.py
+++ b/tests/test_fal_no_double_billing.py
@@ -1,0 +1,118 @@
+"""fal calls must bill exactly once per task.
+
+The regression these lock down: `_call_with_retry` wrapped
+`fal_client.subscribe` in a 4-attempt loop, and subscribe SUBMITS — so every
+retry minted a new request_id, i.e. another paid generation charged against a
+single manna spend. It decided to retry by substring-matching str(e) for any
+number in 500..599, so a 422 whose detail carried "240x240" or a docs URL was
+read as a server error and re-billed three more times.
+
+fal_client already retries 408/409/429/5xx internally on every HTTP request
+(client._should_retry), so the safe retry still happens — one layer down,
+before a job exists.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from eve.tools.fal_tool import _format_error_for_user, call_fal
+
+
+def _fal_error(status: int, detail: str) -> Exception:
+    """A FalClientError shaped exactly as fal_client raises it."""
+    from fal_client.client import FalClientError
+
+    request = httpx.Request("POST", "https://queue.fal.run/fal-ai/x")
+    response = httpx.Response(status, request=request)
+    cause = httpx.HTTPStatusError("err", request=request, response=response)
+    err = FalClientError(detail)
+    err.__cause__ = cause
+    return err
+
+
+def _handle(result=None, exc=None):
+    handle = MagicMock()
+    handle.request_id = "req-abc"
+    handle.iter_events.return_value = iter(())
+    if exc is not None:
+        handle.get.side_effect = exc
+    else:
+        handle.get.return_value = result
+    return handle
+
+
+# ---------------------------------------------------------------------------
+# exactly-once submission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_submits_once():
+    handle = _handle(result={"images": [{"url": "https://x/1.png"}]})
+    with patch("fal_client.submit", return_value=handle) as submit:
+        out = await call_fal("fal-ai/x", {"prompt": "hi"}, with_logs=False)
+    assert submit.call_count == 1
+    assert out == {"images": [{"url": "https://x/1.png"}]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [422, 429, 500, 503])
+async def test_failure_after_acceptance_never_resubmits(status):
+    """Once fal accepts the job it is billable — including on a 5xx or 429."""
+    handle = _handle(exc=_fal_error(status, "boom"))
+    with patch("fal_client.submit", return_value=handle) as submit:
+        with pytest.raises(ValueError):
+            await call_fal("fal-ai/x", {"prompt": "hi"}, with_logs=False)
+    assert submit.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_after_acceptance_never_resubmits():
+    """A timeout means the job most likely RAN and was billed. Never buy it twice."""
+    handle = _handle(exc=httpx.ReadTimeout("timed out"))
+    with patch("fal_client.submit", return_value=handle) as submit:
+        with pytest.raises(ValueError):
+            await call_fal("fal-ai/x", {"prompt": "hi"}, with_logs=False)
+    assert submit.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_failure_is_not_retried_here():
+    """fal_client retries the submit POST itself; we must not stack another loop."""
+    with patch(
+        "fal_client.submit", side_effect=_fal_error(500, "bad gateway")
+    ) as submit:
+        with pytest.raises(ValueError):
+            await call_fal("fal-ai/x", {"prompt": "hi"}, with_logs=False)
+    assert submit.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# classification by real status, not by substring
+# ---------------------------------------------------------------------------
+
+
+def test_422_carrying_5xx_digits_is_not_a_server_error():
+    """The exact prod string that the old predicate re-billed three times."""
+    detail = (
+        "[{'loc': ['body', 'image_url'], 'msg': 'Image dimensions are too small. "
+        "Minimum dimensions are 240x240 pixels.', 'type': 'image_too_small', "
+        "'url': 'https://docs.fal.ai/errors#image_too_small'}]"
+    )
+    msg = _format_error_for_user(_fal_error(422, detail))
+    assert msg.startswith("FAL rejected the request (422)")
+    assert "server error" not in msg.lower()
+    assert "240x240" in msg  # the actionable detail survives
+
+
+def test_real_5xx_is_reported_as_a_server_error():
+    msg = _format_error_for_user(_fal_error(503, "Service Unavailable"))
+    assert "FAL server error (503)" in msg
+
+
+def test_status_beats_a_message_that_merely_mentions_429():
+    msg = _format_error_for_user(_fal_error(400, "seed 429000 is out of range"))
+    assert msg.startswith("FAL rejected the request (400)")
+    assert "rate limit" not in msg.lower()

--- a/tests/test_no_retry_on_paid_generation.py
+++ b/tests/test_no_retry_on_paid_generation.py
@@ -1,0 +1,225 @@
+"""A paid generation must be bought exactly once per manna charge.
+
+Manna is spent up front, once, before the handler runs
+(Tool.handle_start_task). Any retry that re-issues the provider request after
+the provider has accepted the work therefore buys the same output twice or
+three times against a single charge — and refunds only ever return the one
+charge, so every extra provider attempt is pure loss.
+
+Covers the two non-fal offenders (fal has its own file,
+test_fal_no_double_billing.py):
+
+* ElevenLabs — five paid handlers wrapped generation in
+  ``async_exponential_backoff``, which retries a bare ``Exception``: a 422 was
+  re-billed exactly like a 503.
+* Runway — three handlers wrapped ``*.create`` in tenacity with
+  ``retry_if_exception_type((APIConnectionError, APIStatusError))``, and
+  ``APIStatusError`` is the base class of every 4xx and 5xx.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import runwayml
+
+from eve.tool import ToolContext
+from eve.utils.system_utils import async_retry_if_unbilled
+
+# ---------------------------------------------------------------------------
+# ElevenLabs: the shared predicate
+# ---------------------------------------------------------------------------
+
+
+def _http_error(status: int) -> Exception:
+    request = httpx.Request("POST", "https://api.elevenlabs.io/v1/music")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("err", request=request, response=response)
+
+
+async def _counting(exc):
+    """A paid call that always fails, counting how many times it was made."""
+    calls = []
+
+    async def call():
+        calls.append(1)
+        raise exc
+
+    return call, calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 401, 404, 422, 500, 503])
+async def test_billable_failures_are_not_retried(status):
+    """Anything the provider may have generated for is bought once, not thrice.
+
+    5xx is included on purpose: ElevenLabs can render the audio and still fail
+    to deliver the response, so a 500 is not provably unbilled.
+    """
+    call, calls = await _counting(_http_error(status))
+    with pytest.raises(httpx.HTTPStatusError):
+        await async_retry_if_unbilled(call, max_attempts=3, initial_delay=0)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_is_not_retried():
+    """A read timeout means the request WAS sent; the audio may already exist."""
+    call, calls = await _counting(httpx.ReadTimeout("timed out"))
+    with pytest.raises(httpx.ReadTimeout):
+        await async_retry_if_unbilled(call, max_attempts=3, initial_delay=0)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_bug_is_not_retried():
+    """The bare KeyError('voice') that used to burn three attempts and 4 minutes."""
+    call, calls = await _counting(KeyError("voice"))
+    with pytest.raises(KeyError):
+        await async_retry_if_unbilled(call, max_attempts=3, initial_delay=0)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [httpx.ConnectError("no route"), httpx.ConnectTimeout("nope"), _http_error(429)],
+)
+async def test_provably_unbilled_failures_are_retried(exc):
+    """Never connected, or rejected outright — nothing was generated."""
+    call, calls = await _counting(exc)
+    with pytest.raises(type(exc)):
+        await async_retry_if_unbilled(call, max_attempts=3, initial_delay=0)
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_recovers_after_a_transient_connect_failure():
+    calls = []
+
+    async def call():
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ConnectError("no route")
+        return "audio"
+
+    assert await async_retry_if_unbilled(call, max_attempts=3, initial_delay=0) == (
+        "audio"
+    )
+    assert len(calls) == 2
+
+
+def test_vendor_sdk_status_codes_are_understood():
+    """The ElevenLabs SDK raises ApiError(status_code=...), not an httpx error."""
+    from elevenlabs.core.api_error import ApiError
+
+    from eve.utils.system_utils import _is_provably_unbilled
+
+    assert _is_provably_unbilled(ApiError(status_code=429))
+    assert not _is_provably_unbilled(ApiError(status_code=422))
+    assert not _is_provably_unbilled(ApiError(status_code=500))
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs: elevenlabs_speech validates segments before spending anything
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "segments",
+    [
+        [{"text": "hello"}],  # the prod failure: no 'voice'
+        [{"voice": "Charlotte"}],
+        [{"text": "hi", "voice": "Charlotte"}, {"text": "there"}],
+    ],
+)
+async def test_speech_rejects_incomplete_segments_before_calling_out(segments):
+    from eve.tools.elevenlabs_speech import handler as speech
+
+    with patch.object(speech, "eleven") as eleven:
+        with pytest.raises(ValueError) as excinfo:
+            await speech.handler(ToolContext(args={"segments": segments}))
+
+    # Actionable, and no provider call was made.
+    assert "missing required field" in str(excinfo.value)
+    eleven.voices.get_all.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Runway: submit once
+# ---------------------------------------------------------------------------
+
+
+def _runway_error(status: int) -> runwayml.APIStatusError:
+    request = httpx.Request("POST", "https://api.dev.runwayml.com/v1/image_to_video")
+    response = httpx.Response(status, request=request, text="boom")
+    return runwayml.APIStatusError("boom", response=response, body=None)
+
+
+RUNWAY_CASES = [
+    (
+        "eve.tools.runway.handler",
+        "image_to_video",
+        {
+            "prompt_text": "a cat",
+            "ratio": "16:9",
+            "duration": 5,
+            "start_image": "https://x/a.png",
+        },
+    ),
+    (
+        "eve.tools.runway2.handler",
+        "character_performance",
+        {
+            "ratio": "16:9",
+            "character_image": "https://x/a.png",
+            "reference_video": "https://x/a.mp4",
+            "body_control": True,
+            "expression_intensity": 3,
+            "seed": 1,
+        },
+    ),
+    (
+        "eve.tools.runway3.handler",
+        "video_to_video",
+        {"input_video": "https://x/a.mp4", "prompt_text": "film noir", "ratio": "16:9"},
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 429, 500])
+@pytest.mark.parametrize("module,namespace,args", RUNWAY_CASES)
+async def test_runway_submits_exactly_once(module, namespace, args, status):
+    """A failed create is never re-issued — a second create is a second paid task.
+
+    400 is the one the old predicate got most wrong (APIStatusError is its base
+    class, so a deterministic client error was "retryable"); 429 and 500 are
+    already retried inside the runwayml SDK, one layer down, before a task
+    exists.
+    """
+    import importlib
+
+    mod = importlib.import_module(module)
+
+    create = AsyncMock(side_effect=_runway_error(status))
+    client = MagicMock()
+    getattr(client, namespace).create = create
+
+    with patch.object(mod, "AsyncRunwayML", return_value=client):
+        with pytest.raises(Exception):
+            await mod.handler(ToolContext(args=args))
+
+    assert create.call_count == 1
+
+
+@pytest.mark.parametrize("module,_namespace,_args", RUNWAY_CASES)
+def test_runway_handlers_have_no_retry_wrapper(module, _namespace, _args):
+    """Guard the regression at the source: no tenacity in the submit path."""
+    import importlib
+    import inspect
+
+    source = inspect.getsource(importlib.import_module(module))
+    assert "tenacity" not in source
+    assert "@retry" not in source


### PR DESCRIPTION
## Why

Manna is charged **once, up front**, before anything is submitted (`eve/tool.py:815`, `task.spend_manna()` in `Tool.handle_start_task`). Three provider paths then retried the **generation** call on top of that, so a single charge could buy the same output two, three or four times.

In every case the retry layer sat on top of an SDK that **already retries the safe part** — the submit/create HTTP request, before a job exists, for free:

| | outer retry | what the SDK already does |
|---|---|---|
| fal | 4× around `fal_client.subscribe` (= submit + poll + fetch) | `_should_retry`: `408/409/429/5xx` on the submit POST |
| ElevenLabs | 3× around the generation call, on bare `Exception` | — (raw `httpx`) |
| Runway | 3× around `*.create`, on `APIStatusError` (base class of every 4xx **and** 5xx) | `BaseClient._should_retry`: connection errors + `408/409/429/5xx`, `DEFAULT_MAX_RETRIES=2` |

## What changed

### 1. fal — submit once, poll to completion (`eve/tools/fal_tool.py`)

`fal_client.subscribe` **submits**, so re-entering it minted a new `request_id` and a new billable generation: **1 manna charge, up to 4 fal bills**. It decided when to do that by substring-matching `str(e)` for any number in `500..599`, so a 422 whose detail carried `"240x240"` or a docs URL was read as a server error and re-billed three more times.

- New module-level `call_fal(endpoint, args, with_logs=True)`: `fal_client.submit` once, then drain the handle to completion. Polls are free, idempotent, and already retried inside `fal_client`.
- Past the submit line fal owns a billable job and it is never resubmitted. The `request_id` is logged on failure, so an accepted-but-orphaned job stays recoverable by **polling**, not resubmission.
- The helper had been copy-pasted into **four** places (`fal_tool.py:38/98`, and the three `nano_banana*_fal` handlers). There is now one implementation; `nano_banana_2_fal` keeps `call_fal_with_retry = call_fal` as an alias so its **6 downstream importers** (`seedance2`, `seedance2_reference`, `vidu_reference`, `wan_27`, `flux_dev_fal`, `gpt_image_2`) are untouched.
- `nano_banana_2_fal`'s `_format_error_for_user` is now the shared one: it reads the status code off the chained `httpx.HTTPStatusError` cause rather than digit-matching the message, and it preserves fal's real detail so an outage is distinguishable from our own bad input.

**Not touched:** the `handler: fal` webhook path (`async_start_task` → `submit(webhook_url=…)` → `/update-fal` → `fal_update_task`). It already submits once, claims atomically and finalizes idempotently. Only the blocking `subscribe` path was broken.

### 2. ElevenLabs — retry only what is provably unbilled

`async_exponential_backoff` (`eve/utils/system_utils.py:67`) retries **any `Exception`** with no classification, and wrapped paid generation at 5 call sites (`elevenlabs`, `elevenlabs_dialogue`, `elevenlabs_fx`, `elevenlabs_music`, `elevenlabs_speech`). A 400, a 422 and a local `KeyError` were re-billed exactly like a 503.

Its per-attempt `asyncio.wait_for(…, 300)` made it worse: `wait_for` cannot cancel the thread running the HTTP request, so a music generation slower than 300s (that endpoint allows 600s) was abandoned mid-flight and **re-issued while the first was still generating and billing**.

I checked every caller before changing anything. `async_exponential_backoff` also has genuinely free/idempotent callers (`memory2` fact/reflection/consolidation extraction, `runner_tasks` thumbnails, `reel/handler_old`), so **the shared helper is unchanged** and the paid call sites moved instead:

- New `async_retry_if_unbilled` alongside it. It retries only failures the provider **cannot** have billed for: the connection was never established (`ConnectError`, `ConnectTimeout`, `PoolTimeout`), or the provider answered **429** and generated nothing.
- 5xx and read timeouts are excluded on purpose — those can fire *after* the audio exists and only the delivery of the response failed.
- No outer `wait_for`; the per-request `httpx` timeouts (120s / 600s) already bound each attempt, and the task watchdog bounds the whole thing.

**Also fixed** the bare `KeyError: 'voice'` in `elevenlabs_speech` (17 occurrences in prod, part of its 36.5% failure rate). `voice` and `text` are declared `required: true` on the segment *item* schema, but nested object properties inside an array aren't enforced by parameter validation, so a segment missing `voice` reached the generator and died opaquely — three times over, thanks to the retry wrapper. It now fails up front with a message naming the missing field and pointing at `elevenlabs_search_voices`.

### 3. Runway — submit once (`runway`, `runway2`, `runway3`)

`retry_if_exception_type((APIConnectionError, APIStatusError))` — and `APIStatusError` is the base class of **every 4xx and 5xx**, so a deterministic 400 counted as retryable on a paid `image_to_video.create` / `character_performance.create` / `video_to_video.create`.

**Honest finding:** in practice the decorator was **inert**. Every branch of the function body converts the SDK error into a bare `Exception(...)` before tenacity sees it, so `retry_if_exception_type` never matched and no retry ever fired. I verified this empirically — `test_runway_submits_exactly_once` passes against `origin/main` too. So this is landmine removal, not a live-bug fix: anyone reordering or removing one of those `except` clauses would have armed a 3× double-submit on every 400.

Rather than re-arm it with a narrower predicate, the decorator is removed and replaced with a comment explaining why there is no retry. The `runwayml` SDK already retries connection errors and `408/409/429/5xx` internally on the create POST, before a Runway task exists.

## Manna accounting

Unchanged on every path — no new charge or refund surface.

| path | charge | refund |
|---|---|---|
| fal blocking (`subscribe` → `call_fal`) | one `spend_manna` before dispatch, as today | handler raises → existing `handle_run`/`handle_start_task` failure path refunds once |
| fal webhook (`handler: fal`) | untouched | untouched — atomic claim + idempotent `fal_update_task` |
| ElevenLabs ×5 | one `spend_manna` before dispatch | handler raises → one refund; the new up-front `segments` validation raises *earlier*, on the same path |
| Runway ×3 | one `spend_manna` before dispatch | unchanged |

Refunds remain idempotent through the unique `{task,type}` index (`eve/task.py:438`). Nothing here charges, refunds, or retries a charge; the only thing that changes is how many times we ask the *provider* to do paid work per charge.

## Tests

`tests/test_fal_no_double_billing.py` (10) and `tests/test_no_retry_on_paid_generation.py` (28), plus the existing `tests/test_fal_webhook.py` (14) re-run green.

```
$ pytest tests/ -q -m "not live and not integration"
111 passed, 32 deselected, 85 warnings in 6.84s
```

(The 32 deselected are the `live`/`integration` tests in `test_llm_providers.py` and `test_artifacts.py`, which make real provider calls.)

All 11 fal tool modules still import, and `ruff check` / `ruff format` are clean on every file touched.

## Noted in passing, deliberately not fixed here

- **`runway2` / `runway3` are 100% failing against retired model IDs.** `gen4_aleph` no longer exists; Runway now lists `aleph2`. Not attempted here — it needs a real model-id migration and its own verification.
- **`runway` and `runway2` swallow the submit error.** When `create_*` fails and it wasn't a content-safety rejection, the outer `except` discards the real exception: `runway` then raises a generic `"No task was returned"`, and `runway2` hits an `UnboundLocalError` because `task` was never assigned. Both hide the actual cause. Out of scope for a retry-semantics PR, but worth a follow-up.
- **Nested `required` isn't enforced for array item properties.** `elevenlabs_speech` is patched at the handler, but `elevenlabs_dialogue` has the identical `segment["voice"]` / `segment["text"]` shape and the same latent failure. The real fix is in parameter validation, not in each handler.
- **`async_exponential_backoff`'s per-attempt `wait_for` cannot cancel the work it abandons.** Left as-is for its remaining free/idempotent callers, where an abandoned attempt costs nothing — but it is a trap for any future paid caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
