### PR TITLE
feat(pricing): one place to set a tool's price

### DIFF
--- a/.github/workflows/pricing-check.yaml
+++ b/.github/workflows/pricing-check.yaml
@@ -1,0 +1,86 @@
+name: Tool Pricing Drift Check
+
+# Proves that the price in the repo is the price the database charges.
+#
+# PROD is a required check: it is where money moves, and any disagreement
+# between api.yaml and tools3 means someone is being charged something nobody
+# wrote down. STAGE is advisory -- it legitimately carries in-development tools
+# and experimental prices that were never meant to reach a repo.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+  push:
+    branches:
+      - main
+      - staging
+  workflow_dispatch:
+
+jobs:
+  pricing-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - db: PROD
+            blocking: true
+          - db: STAGE
+            blocking: false
+
+    steps:
+      # Lay the repos out the way eve.tool.get_api_files() expects them:
+      # <root>/eve/eve/tools, <root>/workflows, <root>/private_workflows
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          path: eve
+
+      - name: Checkout workflows repo
+        uses: actions/checkout@v4
+        with:
+          repository: edenartlab/workflows
+          path: workflows
+
+      # Optional: only possible if a token for the private repo is configured.
+      # Without it the check reports private_workflows as UNCHECKED and never
+      # treats its tools as missing or unpriced.
+      - name: Checkout private_workflows repo
+        id: private
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: edenartlab/private_workflows
+          token: ${{ secrets.PRIVATE_WORKFLOWS_PAT }}
+          path: private_workflows
+
+      - name: Note private_workflows availability
+        run: |
+          if [ "${{ steps.private.outcome }}" = "success" ]; then
+            echo "private_workflows checked out; its tools are included."
+          else
+            echo "::notice::private_workflows not available; its tools are reported as UNCHECKED, not as drift."
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install the latest version of rye
+        uses: eifinger/setup-rye@v4
+
+      - name: Install dependencies
+        working-directory: eve
+        run: rye sync
+
+      - name: Check tool prices against ${{ matrix.db }}
+        working-directory: eve
+        continue-on-error: ${{ !matrix.blocking }}
+        env:
+          MONGO_URI: ${{ matrix.db == 'PROD' && secrets.MONGO_URI_PROD || secrets.MONGO_URI_STG }}
+          MONGO_DB_NAME: ${{ matrix.db == 'PROD' && 'eden-prod' || 'eden-stg' }}
+          DB: ${{ matrix.db }}
+        run: rye run eve tool price-check --db ${{ matrix.db }}

--- a/.github/workflows/update-tools.yaml
+++ b/.github/workflows/update-tools.yaml
@@ -46,9 +46,30 @@ jobs:
             for file in $CHANGED_FILES; do
               # Extract tool name: get the directory containing api.yaml
               TOOL_NAME=$(dirname "$file" | xargs basename)
+              # get_api_files() prefixes anything under a legacy/ path. Without
+              # this the name matches no tool and the update silently does
+              # nothing -- which is how legacy tools drifted in the first place.
+              case "$file" in
+                *"/legacy/"*) TOOL_NAME="legacy_$TOOL_NAME" ;;
+              esac
               echo "Updating tool: $TOOL_NAME in $DB"
-              rye run eve tool update --db $DB "$TOOL_NAME"
+              # --yes: non-interactive. The price-erasure guard still applies
+              # and will fail the job rather than zero out a live price.
+              rye run eve tool update --db $DB --yes "$TOOL_NAME"
             done
           else
             echo "No api.yaml files changed"
           fi
+
+      # Confirm the database now says what the repo says. Without this the
+      # sync is fire-and-forget: a tool that failed to update looks identical
+      # to one that succeeded.
+      - name: Verify no price drift remains
+        # Blocking on main/PROD. Advisory on staging, which carries
+        # experimental prices that deliberately differ from the repo.
+        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        env:
+          MONGO_URI: ${{ github.ref == 'refs/heads/main' && secrets.MONGO_URI_PROD || secrets.MONGO_URI_STG }}
+          MONGO_DB_NAME: ${{ github.ref == 'refs/heads/main' && 'eden-prod' || 'eden-stg' }}
+          DB: ${{ github.ref == 'refs/heads/main' && 'PROD' || 'STAGE' }}
+        run: rye run eve tool price-check --db $DB

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: help price price-prod price-check price-check-stage price-sync price-sync-stage test
+
+DB ?= PROD
+
+help:
+	@echo "Tool pricing"
+	@echo "  make price TOOL=flux_dev   what does one tool cost, and does the repo agree?"
+	@echo "  make price                 audit every tool against PROD"
+	@echo "  make price-check           fail if the repo and PROD disagree (what CI runs)"
+	@echo "  make price-check-stage     same, against STAGE"
+	@echo "  make price-sync            push the repo's prices to PROD (asks first)"
+	@echo "  make price-sync-stage      push the repo's prices to STAGE (asks first)"
+	@echo ""
+	@echo "  To change a price: edit cost_estimate in the tool's api.yaml and merge."
+	@echo ""
+	@echo "Tests"
+	@echo "  make test                  run the offline test suite"
+
+## What does this tool cost right now, and does the repo agree?
+## Usage: make price TOOL=flux_dev [DB=PROD|STAGE]
+price:
+	eve tool price --db $(DB) $(TOOL)
+
+price-check:
+	eve tool price-check --db PROD
+
+price-check-stage:
+	eve tool price-check --db STAGE
+
+price-sync:
+	eve tool price-sync --db PROD
+
+price-sync-stage:
+	eve tool price-sync --db STAGE
+
+test:
+	pytest tests/ -q -m "not live and not integration"

--- a/README.md
+++ b/README.md
@@ -37,3 +37,35 @@ We invite you to contribute workflows that will become accessible to all creativ
 - Run `docker compose up falkordb` to start a local FalkorDB instance (default port `6380` mapped to the container’s `6379` and web UI on `http://localhost:8380`).
 - Authentication is disabled by default. Set `FALKORDB_USERNAME` and `FALKORDB_PASSWORD` in your shell only if you enable credentials on a remote instance.
 - Use `redis-cli -h localhost -p 6380` (or another Redis client) to verify the database is reachable before running integrations. Override the host/UI ports with `FALKORDB_PORT` and `FALKORDB_WEB_PORT` if needed.
+
+## Tool pricing
+
+**A tool's price lives in exactly one place: the `cost_estimate` field of its
+`api.yaml`.** To change a price, edit that line and merge the PR. CI writes the
+new value to the `tools3` collection, which is what production charges against.
+Nobody should ever need to edit Mongo by hand.
+
+```bash
+make price TOOL=flux_dev   # what does it cost now, and does the repo agree?
+make price                 # the same question for every tool
+make price-check           # fail if the repo and PROD disagree (this runs in CI)
+```
+
+`eve tool price-check` runs on every PR against PROD as a required check, so a
+price can never quietly diverge from what the repo says. If it ever does,
+`eve tool price-sync --db PROD` pushes the repo's prices to the database.
+
+Three things are worth knowing:
+
+- **Prices are inherited.** A tool with `parent_tool` and no `cost_estimate`
+  uses its parent's. `eve tool price <name>` tells you which file the number
+  actually came from.
+- **Some tools exist only in the database** (retired workflows). Syncing never
+  deletes; those keys are listed in `eve/db_only_tools.yaml`, and a database
+  tool that is *not* listed and *not* in a repo fails the check.
+- **Tools live in three repos** — `eve`, `workflows`, `private_workflows`. A
+  repo that is not checked out is reported as UNCHECKED and its tools are
+  skipped, never treated as deleted or unpriced.
+
+STAGE is deliberately not a required check: it carries in-development tools and
+experimental prices that are not expected to match any repo.

--- a/eve/cli/tool_cli.py
+++ b/eve/cli/tool_cli.py
@@ -8,11 +8,12 @@ import traceback
 
 import click
 
-from .. import load_env
+from .. import load_env, pricing
 from ..agent import Agent
 from ..auth import get_my_eden_user
 from ..tool import Tool, get_api_files, get_tools_from_api_files, get_tools_from_mongo
 from ..utils import CLICK_COLORS, dumps_json, prepare_result, save_test_results
+from ..utils.cost_utils import eval_cost
 
 api_tools_order = [
     "txt2img",
@@ -150,8 +151,20 @@ def tool():
     default="STAGE",
     help="DB to save against",
 )
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt (for CI). The price guard still applies.",
+)
+@click.option(
+    "--allow-price-removal",
+    is_flag=True,
+    default=False,
+    help="Permit writing an absent/zero cost_estimate over a real one. Dangerous.",
+)
 @click.argument("names", nargs=-1, required=False)
-def update(db: str, names: tuple):
+def update(db: str, names: tuple, yes: bool, allow_price_removal: bool):
     """Upload tools to mongo"""
 
     load_env(db)
@@ -160,19 +173,88 @@ def update(db: str, names: tuple):
     tools_order = {t: index for index, t in enumerate(api_tools_order)}
 
     if names:
+        missing = [n for n in names if n not in api_files]
+        if missing:
+            raise click.ClickException(
+                f"No api.yaml found for: {', '.join(sorted(missing))}"
+            )
         api_files = {k: v for k, v in api_files.items() if k in names}
-    else:
-        confirm = click.confirm(
-            f"Update all {len(api_files)} tools on {db}?", default=False
+
+    # Load every tool up front so the price diff can be shown *before* anything
+    # is written. This is the whole point of the confirmation: a bulk update
+    # used to be a blind "update all N tools?" with no idea what would change.
+    db_prices = pricing.collect_db_prices()
+    loaded, failed = [], []
+    for key, api_file in api_files.items():
+        try:
+            loaded.append((key, Tool.from_yaml(api_file)))
+        except Exception as e:
+            traceback.print_exc()
+            click.echo(click.style(f"Failed to load tool {db}:{key}: {e}", fg="red"))
+            failed.append(key)
+
+    # Guard: never let an absent or zeroed price overwrite a real one. This is
+    # the single check that turns "oops, five tools are now free" into an error.
+    blocked, changes = [], []
+    for key, tool_ in loaded:
+        # Tool.convert_from_yaml derives the stored key itself, and for tools
+        # with a parent_tool it can differ from the CLI's name for the file.
+        stored_key = getattr(tool_, "key", key)
+        if stored_key != key:
+            click.echo(
+                click.style(
+                    f"note: {key} is stored under key '{stored_key}'", fg="yellow"
+                )
+            )
+        old, new = db_prices.get(stored_key), getattr(tool_, "cost_estimate", None)
+        if pricing.would_erase_price(old, new) and not allow_price_removal:
+            blocked.append((key, stored_key, old, new))
+        elif pricing.normalize(old) != pricing.normalize(new):
+            changes.append((key, stored_key, old, new))
+
+    if blocked:
+        click.echo(
+            click.style(
+                f"\nRefusing to update {len(blocked)} tool(s): this would erase a "
+                f"live price on {db}.",
+                fg="red",
+                bold=True,
+            )
         )
-        if not confirm:
+        for key, stored_key, old, new in blocked:
+            click.echo(click.style(f"  {key} (key={stored_key})", fg="red"))
+            click.echo(f"      db  : {old!r}")
+            click.echo(f"      repo: {new!r}")
+        click.echo(
+            "\nFix the cost_estimate in api.yaml, or pass --allow-price-removal "
+            "if the tool really should be free."
+        )
+        raise click.ClickException(f"Blocked {len(blocked)} price-erasing update(s)")
+
+    if changes:
+        click.echo(click.style(f"\nPrice changes to apply on {db}:", bold=True))
+        for key, stored_key, old, new in changes:
+            click.echo(f"  {key}: {old!r} -> {new!r}")
+    else:
+        click.echo(click.style(f"\nNo price changes on {db}.", fg="green"))
+
+    # A bulk update -- no names given -- is the dangerous one: it rewrites every
+    # tool document on the database. That always confirms, and the diff above
+    # is what you are confirming. Named updates stay non-interactive so the
+    # existing deploy workflow keeps working.
+    if not names and not yes:
+        if not click.confirm(
+            f"\nUpdate ALL {len(loaded)} tool(s) on {db} "
+            f"({len(changes)} price change(s))?",
+            default=False,
+        ):
+            click.echo("Aborted.")
             return
 
     updated = 0
-    for key, api_file in api_files.items():
+    for key, tool_ in loaded:
         try:
             order = tools_order.get(key, len(api_tools_order))
-            tool_ = Tool.from_yaml(api_file)
             tool_.save(order=order)
             click.echo(
                 click.style(f"Updated tool {db}:{key} (order={order})", fg="green")
@@ -181,6 +263,7 @@ def update(db: str, names: tuple):
         except Exception as e:
             traceback.print_exc()
             click.echo(click.style(f"Failed to update tool {db}:{key}: {e}", fg="red"))
+            failed.append(key)
 
     click.echo(
         click.style(
@@ -189,10 +272,8 @@ def update(db: str, names: tuple):
     )
 
     # Exit with error code if any updates failed
-    if updated < len(api_files):
-        raise click.ClickException(
-            f"Failed to update {len(api_files) - updated} tool(s)"
-        )
+    if failed:
+        raise click.ClickException(f"Failed to update {len(failed)} tool(s)")
 
 
 @tool.command()
@@ -227,6 +308,161 @@ def remove(db: str, names: tuple):
     click.echo(
         click.style(f"Deleted {deleted} of {len(names)} tools", fg="red", bold=True)
     )
+
+
+_DB_OPTION = click.option(
+    "--db",
+    type=click.Choice(["STAGE", "PROD"], case_sensitive=False),
+    default="STAGE",
+    help="DB to compare against",
+)
+
+
+@tool.command()
+@_DB_OPTION
+@click.argument("name", required=False)
+def price(db: str, name: str):
+    """What does a tool cost right now, and does the repo agree?
+
+    With NAME, shows that one tool. Without, audits every tool.
+    """
+    load_env(db)
+
+    repos, missing = pricing.discover_repos()
+    yaml_prices, collisions, unresolved = pricing.collect_yaml_prices(repos)
+
+    if not name:
+        report = pricing.compute_drift(
+            yaml_prices=yaml_prices,
+            db_prices=pricing.collect_db_prices(),
+            db_only=pricing.load_db_only_registry(),
+            checked_repos=list(repos),
+            unchecked_repos=missing,
+            collisions=collisions,
+            unresolved_parent=unresolved,
+            flag_db_only=db.upper() == "PROD",
+        )
+        click.echo(pricing.format_report(report, db))
+        return
+
+    from ..mongo import get_collection
+
+    doc = get_collection("tools3").find_one(
+        {"key": name}, {"key": 1, "cost_estimate": 1}
+    )
+    db_cost = doc.get("cost_estimate") if doc else None
+    yaml_price = yaml_prices.get(name)
+
+    click.echo(click.style(f"\n{name}", bold=True))
+    click.echo(f"  live on {db}: {db_cost!r}" if doc else f"  live on {db}: NOT IN DB")
+
+    if yaml_price:
+        click.echo(f"  in repo    : {yaml_price.cost_estimate!r}")
+        click.echo(f"  defined in : {yaml_price.source}")
+    else:
+        click.echo("  in repo    : no api.yaml found")
+        if missing:
+            click.echo(
+                click.style(
+                    f"  (repos not checked out: {', '.join(missing)} -- the "
+                    f"definition may live there)",
+                    fg="yellow",
+                )
+            )
+        elif name in pricing.load_db_only_registry():
+            click.echo("  (registered as a database-only tool)")
+
+    if yaml_price and doc:
+        agree = pricing.normalize(yaml_price.cost_estimate) == pricing.normalize(db_cost)
+        click.echo(
+            click.style("  AGREES", fg="green")
+            if agree
+            else click.style("  DRIFTED - repo and database disagree", fg="red")
+        )
+
+    expression = yaml_price.cost_estimate if yaml_price else db_cost
+    error = pricing.validate_expression(expression)
+    if error:
+        click.echo(click.style(f"  INVALID EXPRESSION: {error}", fg="red"))
+
+    # Evaluate against the tool's own test args, when it has some.
+    if yaml_price and expression:
+        test_file = yaml_price.path.replace("api.yaml", "test.json")
+        if os.path.exists(test_file):
+            try:
+                with open(test_file, "r") as f:
+                    args = json.load(f)
+                cost = eval_cost(expression, **args)
+                click.echo(f"  test args  : {json.dumps(args)}")
+                click.echo(
+                    click.style(
+                        f"  -> {cost} manna (${float(cost) / 100:.2f})", fg="cyan"
+                    )
+                )
+                # An identifier the test args don't supply evaluates to 0, so
+                # say so rather than quietly reporting a cost that is too low.
+                absent = [
+                    n for n in pricing.free_identifiers(expression) if n not in args
+                ]
+                if absent:
+                    click.echo(
+                        click.style(
+                            f"     (test args do not set {', '.join(absent)}; "
+                            f"treated as 0 -- this is not the real cost)",
+                            fg="yellow",
+                        )
+                    )
+            except Exception as e:
+                click.echo(click.style(f"  test-arg evaluation failed: {e}", fg="yellow"))
+    click.echo("")
+
+
+@tool.command("price-check")
+@_DB_OPTION
+def price_check(db: str):
+    """Fail if any tool's price in the repo disagrees with the database."""
+    load_env(db)
+    report = pricing.check(flag_db_only=db.upper() == "PROD")
+    click.echo(pricing.format_report(report, db))
+    if not report.ok:
+        raise click.ClickException(
+            "Tool prices in the repo do not match the database. "
+            "Run `eve tool price-sync --db " + db + "` to push the repo's prices."
+        )
+
+
+@tool.command("price-sync")
+@_DB_OPTION
+@click.option("--yes", is_flag=True, default=False, help="Skip confirmation (for CI).")
+@click.pass_context
+def price_sync(ctx, db: str, yes: bool):
+    """Push the repo's prices to the database for every tool that has drifted."""
+    load_env(db)
+    report = pricing.check(flag_db_only=False)
+
+    if report.invalid or report.unresolved_parent or report.collisions:
+        click.echo(pricing.format_report(report, db))
+        raise click.ClickException("Refusing to sync while the repo is inconsistent.")
+
+    # Only realign tools that already exist. Creating a tool is a deliberate
+    # act (`eve tool update <name>`), not something a price sync should do --
+    # otherwise every local dev/test tool would be published on first run.
+    keys = [key for key, _repo_cost, _db_cost in report.drifted]
+    if report.not_yet_in_db:
+        click.echo(
+            click.style(
+                f"Not creating {len(report.not_yet_in_db)} tool(s) absent from {db}: "
+                f"{', '.join(report.not_yet_in_db)}\n"
+                f"  (run `eve tool update --db {db} <name>` to publish one)",
+                fg="yellow",
+            )
+        )
+    if not keys:
+        click.echo(click.style(f"Nothing to sync: {db} already matches the repo.", fg="green"))
+        return
+
+    click.echo(f"Syncing {len(keys)} tool(s) to {db}: {', '.join(sorted(keys))}")
+    ctx.invoke(update, db=db, names=tuple(keys), yes=yes, allow_price_removal=False)
 
 
 @tool.command(context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))

--- a/eve/db_only_tools.yaml
+++ b/eve/db_only_tools.yaml
@@ -1,0 +1,42 @@
+# Tools that exist in the `tools3` collection but have no api.yaml in any repo.
+#
+# The repo is the source of truth for prices, but it is NOT authoritative about
+# deletion: syncing never removes a tool from the database. These keys are the
+# ones we have deliberately accepted as database-only, as of 2026-08-21.
+#
+# `eve tool price check` fails on any database tool that is not in a repo and
+# not listed here. That is the guard against someone hand-editing Mongo: a new
+# unexplained tool shows up as a CI failure rather than silently becoming
+# untracked. To retire a tool properly, delete it with `eve tool remove`; to
+# price a tool properly, give it an api.yaml.
+#
+# Note on the `legacy_*` pairs below: `eve/tools/legacy/*/api.yaml` files set
+# `parent_tool`, and Tool.convert_from_yaml() derives the stored key from the
+# *folder name* in that case (`controlnet`), while get_api_files() and the CLI
+# address the same file as `legacy_controlnet`. That mismatch is how both
+# spellings came to exist in the database. Prices are currently identical for
+# each pair; see the PR that introduced this file.
+
+db_only_tools:
+  - HelloMeme_image
+  - HelloMeme_video
+  - background_removal_video
+  - controlnet
+  - create_session
+  - eden-comfyui
+  - get_tweets
+  - img2vid
+  - interpolate
+  - layer_diffusion
+  - mars-id
+  - memegen
+  - memory
+  - mochi_preview
+  - ominicontrol
+  - post_to_chatroom
+  - remix
+  - remix_flux_schnell
+  - sd3_txt2img
+  - storydiffusion
+  - time_remapping
+  - video_upscaler

--- a/eve/pricing.py
+++ b/eve/pricing.py
@@ -1,0 +1,475 @@
+"""Single source of truth for tool pricing.
+
+A tool's price is a ``cost_estimate`` expression (see ``eve.utils.cost_utils``).
+It is authored in ``api.yaml`` in a repo and *projected* into the ``tools3``
+collection in Mongo, which is what production reads at runtime.
+
+This module is the one place that knows how to answer:
+
+  * what does the repo say a tool costs?
+  * what does the database say a tool costs?
+  * do they agree?
+
+Three properties of the real system shape this code, and all three are
+load-bearing:
+
+1. **Prices are inherited.** A tool with ``parent_tool`` and no
+   ``cost_estimate`` of its own inherits its parent's price. ``Tool.from_yaml``
+   resolves that inheritance by reading the parent *out of Mongo*
+   (``Tool._get_schema(parent, from_yaml=False)``), which makes "what the repo
+   says" depend on the database and on the order tools happen to be written in.
+   For pricing we resolve inheritance **inside the YAML corpus only**, so the
+   repo answer is a pure function of the repo.
+
+2. **Not every tool has a YAML file.** Some tools exist only in ``tools3``
+   (retired ComfyUI workflows, tools whose source has been deleted). The repo
+   is authoritative for the tools it *can see*; it is never authoritative about
+   deletion. Legitimately DB-only tools are enumerated in
+   ``eve/db_only_tools.yaml`` so that a *new* one -- i.e. someone hand-editing
+   Mongo -- is still caught.
+
+3. **Tools live in three repos.** ``eve``, ``workflows`` and
+   ``private_workflows``. CI does not always have all three checked out. A repo
+   that is absent is reported as UNCHECKED; its tools are never reported as
+   drifted, unpriced, or deleted.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from eve.utils.cost_utils import eval_cost
+
+# Repos that can contain tool definitions, in the same order and at the same
+# locations that eve.tool.get_api_files() searches.
+TOOL_REPOS = ("eve", "workflows", "private_workflows")
+
+DB_ONLY_REGISTRY = os.path.join(os.path.dirname(os.path.abspath(__file__)), "db_only_tools.yaml")
+
+
+@dataclass
+class YamlPrice:
+    """A price as authored in the repo."""
+
+    key: str
+    cost_estimate: Optional[str]
+    path: str
+    repo: str
+    # Set when cost_estimate came from a parent tool rather than this file.
+    inherited_from: Optional[str] = None
+
+    @property
+    def source(self) -> str:
+        if self.inherited_from:
+            return f"{self.path} (inherited from {self.inherited_from})"
+        return self.path
+
+
+@dataclass
+class DriftReport:
+    """The result of comparing repo prices against database prices."""
+
+    # Hard failures.
+    drifted: List[Tuple[str, Optional[str], Optional[str]]] = field(default_factory=list)
+    invalid: List[Tuple[str, str, str]] = field(default_factory=list)
+    unregistered_db_only: List[Tuple[str, Optional[str]]] = field(default_factory=list)
+    unresolved_parent: List[Tuple[str, str]] = field(default_factory=list)
+    collisions: List[Tuple[str, str, str]] = field(default_factory=list)
+
+    # Informational.
+    not_yet_in_db: List[str] = field(default_factory=list)
+    registered_db_only: List[str] = field(default_factory=list)
+    db_only_untracked_info: List[str] = field(default_factory=list)
+    unchecked_repos: List[str] = field(default_factory=list)
+    checked_repos: List[str] = field(default_factory=list)
+    compared: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not (
+            self.drifted
+            or self.invalid
+            or self.unregistered_db_only
+            or self.unresolved_parent
+            or self.collisions
+        )
+
+
+def repo_roots(eve_root: Optional[str] = None) -> Dict[str, str]:
+    """Map repo name -> filesystem root, matching get_api_files()'s layout."""
+    eve_root = eve_root or os.path.dirname(os.path.abspath(__file__))
+    return {
+        "eve": os.path.join(eve_root, "tools"),
+        "workflows": os.path.join(eve_root, "..", "..", "workflows"),
+        "private_workflows": os.path.join(eve_root, "..", "..", "private_workflows"),
+    }
+
+
+def discover_repos(eve_root: Optional[str] = None) -> Tuple[Dict[str, str], List[str]]:
+    """Split the tool repos into those present on disk and those missing."""
+    present, missing = {}, []
+    for name, root in repo_roots(eve_root).items():
+        if os.path.isdir(root):
+            present[name] = os.path.normpath(root)
+        else:
+            missing.append(name)
+    return present, missing
+
+
+def _tool_key(api_file: str) -> str:
+    """Derive a tool key from an api.yaml path, matching get_api_files()."""
+    directory = os.path.dirname(api_file)
+    key = os.path.basename(directory)
+    # Substring test, deliberately identical to get_api_files() so that the
+    # keys this module reports are the keys `eve tool update` accepts.
+    if "legacy" in directory:
+        key = f"legacy_{key}"
+    return key
+
+
+def collect_yaml_prices(
+    repos: Optional[Dict[str, str]] = None,
+    eve_root: Optional[str] = None,
+) -> Tuple[Dict[str, YamlPrice], List[Tuple[str, str, str]], List[Tuple[str, str]]]:
+    """Read every api.yaml in the given repos and resolve effective prices.
+
+    Returns (prices, collisions, unresolved_parents). Inheritance is resolved
+    strictly within the collected corpus -- never against the database.
+    """
+    if repos is None:
+        repos, _ = discover_repos(eve_root)
+
+    raw: Dict[str, Dict[str, Any]] = {}
+    collisions: List[Tuple[str, str, str]] = []
+
+    for repo, root in repos.items():
+        for dirpath, _dirnames, filenames in os.walk(root):
+            if "inactive_workflows" in dirpath.split(os.sep):
+                continue
+            if "api.yaml" not in filenames:
+                continue
+            api_file = os.path.join(dirpath, "api.yaml")
+            try:
+                with open(api_file, "r") as f:
+                    schema = yaml.safe_load(f) or {}
+            except Exception as e:  # malformed YAML is a pricing problem too
+                schema = {"__error__": str(e)}
+
+            key = _tool_key(api_file)
+            if key in raw:
+                prev = raw[key]
+                # Two files claiming one key. Only a real problem if they
+                # disagree about price -- otherwise it is merely untidy.
+                if prev.get("cost_estimate") != schema.get("cost_estimate"):
+                    collisions.append((key, prev["__path__"], api_file))
+                continue
+            schema["__path__"] = api_file
+            schema["__repo__"] = repo
+            raw[key] = schema
+
+    prices: Dict[str, YamlPrice] = {}
+    unresolved: List[Tuple[str, str]] = []
+
+    for key, schema in raw.items():
+        cost = schema.get("cost_estimate")
+        inherited_from = None
+
+        # Walk up the parent chain within the corpus.
+        seen = {key}
+        parent = schema.get("parent_tool")
+        while cost is None and parent:
+            if parent in seen:  # cycle
+                unresolved.append((key, f"circular parent_tool chain via {parent}"))
+                break
+            seen.add(parent)
+            parent_schema = raw.get(parent)
+            if parent_schema is None:
+                unresolved.append((key, f"parent_tool '{parent}' not found in repos"))
+                break
+            cost = parent_schema.get("cost_estimate")
+            inherited_from = parent
+            parent = parent_schema.get("parent_tool")
+
+        prices[key] = YamlPrice(
+            key=key,
+            cost_estimate=None if cost is None else str(cost),
+            path=schema.get("__path__", "?"),
+            repo=schema.get("__repo__", "?"),
+            inherited_from=inherited_from if cost is not None else None,
+        )
+
+    return prices, collisions, unresolved
+
+
+def collect_db_prices() -> Dict[str, Optional[str]]:
+    """Read every tool's cost_estimate out of tools3. Requires load_env()."""
+    from eve.mongo import get_collection
+
+    collection = get_collection("tools3")
+    out: Dict[str, Optional[str]] = {}
+    for doc in collection.find({}, {"key": 1, "cost_estimate": 1}):
+        key = doc.get("key")
+        if not key:
+            continue
+        cost = doc.get("cost_estimate")
+        out[key] = None if cost is None else str(cost)
+    return out
+
+
+def load_db_only_registry(path: str = DB_ONLY_REGISTRY) -> List[str]:
+    """Tools that legitimately have no api.yaml anywhere."""
+    if not os.path.exists(path):
+        return []
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    return list(data.get("db_only_tools") or [])
+
+
+class _Probe(float):
+    """A stand-in value that satisfies every operation the grammar can perform.
+
+    Validation must not need real arguments, but an empty environment binds
+    free variables to None, and None breaks the moment an expression indexes,
+    iterates or takes the length of a parameter -- so perfectly good
+    expressions like `20 * sumLengths(segments, "text")` would look broken.
+    Binding every free identifier to this object instead exercises the whole
+    expression structurally: what survives is a real syntax/shape error.
+
+    It is a float (of value 1, so it is safe as a divisor) that also answers to
+    len(), iteration, indexing and attribute access.
+    """
+
+    __slots__ = ()
+
+    def __new__(cls):
+        return super().__new__(cls, 1.0)
+
+    def __len__(self):
+        return 1
+
+    def __iter__(self):
+        return iter([self])
+
+    def get(self, _key, _default=None):
+        return self
+
+    def __getattr__(self, _name):
+        return self
+
+    def __getitem__(self, _key):
+        return self
+
+
+# Words that are part of the language, not tool parameters.
+_RESERVED = {"true", "false", "null", "none", "not", "length", "sumLengths"}
+_IDENT_RE = None
+
+
+def free_identifiers(expression: str) -> List[str]:
+    global _IDENT_RE
+    if _IDENT_RE is None:
+        import re
+
+        _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+    # Drop string literals first so their contents are not mistaken for names.
+    import re
+
+    stripped = re.sub(r"'[^']*'|\"[^\"]*\"", " ", expression)
+    return [
+        name
+        for name in dict.fromkeys(_IDENT_RE.findall(stripped))
+        if name not in _RESERVED and name.lower() not in _RESERVED
+    ]
+
+
+def validate_expression(expression: Optional[str]) -> Optional[str]:
+    """Return an error string if the expression is not evaluable, else None.
+
+    This turns a pricing typo into a PR-time failure instead of a runtime one:
+    production evaluates these strings on every generation, and a bad one
+    currently only surfaces when a user tries to run the tool.
+    """
+    if expression is None:
+        return None
+    expression = str(expression)
+    variables = {name: _Probe() for name in free_identifiers(expression)}
+    try:
+        result = eval_cost(expression, **variables)
+    except Exception as e:
+        return f"{type(e).__name__}: {e}"
+    if isinstance(result, bool) or not isinstance(result, (int, float)):
+        return f"does not evaluate to a number (got {type(result).__name__}: {result!r})"
+    return None
+
+
+def is_priced(value: Any) -> bool:
+    """True if this cost_estimate actually charges for anything."""
+    return value is not None and str(value).strip() not in ("", "0", "0.0")
+
+
+def would_erase_price(old: Any, new: Any) -> bool:
+    """True if writing ``new`` over ``old`` would make a paid tool free.
+
+    The guard on `eve tool update`. A tool whose api.yaml lost its
+    cost_estimate -- or inherited nothing because its parent could not be
+    resolved -- must never silently zero out a live price.
+    """
+    return is_priced(old) and not is_priced(new)
+
+
+def normalize(expression: Optional[str]) -> Optional[str]:
+    """Compare prices as trimmed strings; whitespace is not a price change."""
+    if expression is None:
+        return None
+    return " ".join(str(expression).split())
+
+
+def compute_drift(
+    yaml_prices: Dict[str, YamlPrice],
+    db_prices: Dict[str, Optional[str]],
+    db_only: Optional[List[str]] = None,
+    checked_repos: Optional[List[str]] = None,
+    unchecked_repos: Optional[List[str]] = None,
+    collisions: Optional[List[Tuple[str, str, str]]] = None,
+    unresolved_parent: Optional[List[Tuple[str, str]]] = None,
+    flag_db_only: bool = True,
+) -> DriftReport:
+    """Compare repo prices against database prices.
+
+    ``flag_db_only`` controls whether a database tool with no api.yaml is an
+    error. It should be True for PROD -- an unexplained tool there means
+    someone hand-edited Mongo -- and False for STAGE, which legitimately
+    carries in-development tools that were never meant to reach a repo.
+    """
+    db_only = set(db_only or [])
+    report = DriftReport(
+        checked_repos=sorted(checked_repos or []),
+        unchecked_repos=sorted(unchecked_repos or []),
+        collisions=list(collisions or []),
+        unresolved_parent=list(unresolved_parent or []),
+    )
+
+    for key in sorted(yaml_prices):
+        price = yaml_prices[key]
+        error = validate_expression(price.cost_estimate)
+        if error:
+            report.invalid.append((key, price.cost_estimate or "", error))
+
+        if key not in db_prices:
+            report.not_yet_in_db.append(key)
+            continue
+
+        report.compared += 1
+        if normalize(price.cost_estimate) != normalize(db_prices[key]):
+            report.drifted.append((key, price.cost_estimate, db_prices[key]))
+
+    # Tools in the database with no api.yaml in any *checked* repo. If some
+    # repos are unchecked we cannot tell "deleted" from "not looked at", so we
+    # only flag these when every repo was available.
+    if not report.unchecked_repos:
+        for key in sorted(db_prices):
+            if key in yaml_prices:
+                continue
+            if key in db_only:
+                report.registered_db_only.append(key)
+            elif flag_db_only:
+                report.unregistered_db_only.append((key, db_prices[key]))
+            else:
+                report.db_only_untracked_info.append(key)
+
+    return report
+
+
+def format_report(report: DriftReport, db_label: str) -> str:
+    """Render a drift report as readable text."""
+    lines: List[str] = []
+    add = lines.append
+
+    add(f"Pricing check against {db_label}")
+    add(f"  repos checked   : {', '.join(report.checked_repos) or '(none)'}")
+    if report.unchecked_repos:
+        add(f"  repos UNCHECKED : {', '.join(report.unchecked_repos)}")
+        add("    (tools defined only in these repos were not compared)")
+    add(f"  tools compared  : {report.compared}")
+
+    if report.drifted:
+        add("")
+        add(f"PRICE DRIFT ({len(report.drifted)}):")
+        for key, repo_cost, db_cost in report.drifted:
+            add(f"  {key}")
+            add(f"    repo: {repo_cost!r}")
+            add(f"    db  : {db_cost!r}")
+
+    if report.invalid:
+        add("")
+        add(f"INVALID COST EXPRESSIONS ({len(report.invalid)}):")
+        for key, expression, error in report.invalid:
+            add(f"  {key}: {expression!r}")
+            add(f"    {error}")
+
+    if report.unresolved_parent:
+        add("")
+        add(f"UNRESOLVED PRICE INHERITANCE ({len(report.unresolved_parent)}):")
+        for key, reason in report.unresolved_parent:
+            add(f"  {key}: {reason}")
+
+    if report.collisions:
+        add("")
+        add(f"DUPLICATE TOOL KEYS WITH DIFFERENT PRICES ({len(report.collisions)}):")
+        for key, first, second in report.collisions:
+            add(f"  {key}:")
+            add(f"    {first}")
+            add(f"    {second}")
+
+    if report.unregistered_db_only:
+        add("")
+        add(f"IN DATABASE BUT NOT IN ANY REPO ({len(report.unregistered_db_only)}):")
+        add("  These have no api.yaml. If that is intentional, add them to")
+        add(f"  {os.path.relpath(DB_ONLY_REGISTRY)}; otherwise restore the file.")
+        for key, cost in report.unregistered_db_only:
+            add(f"  {key}: {cost!r}")
+
+    if report.not_yet_in_db:
+        add("")
+        add(f"in repo, not yet in database ({len(report.not_yet_in_db)}): "
+            f"{', '.join(report.not_yet_in_db)}")
+        add("  (new tools; they are created on the next sync)")
+
+    if report.registered_db_only:
+        add("")
+        add(f"database-only, registered ({len(report.registered_db_only)}): "
+            f"{', '.join(report.registered_db_only)}")
+
+    if report.db_only_untracked_info:
+        add("")
+        add(f"database-only, not in any repo ({len(report.db_only_untracked_info)}): "
+            f"{', '.join(report.db_only_untracked_info)}")
+        add("  (not an error on this database)")
+
+    add("")
+    add("OK - repo and database agree." if report.ok else "FAILED - see above.")
+    return "\n".join(lines)
+
+
+def check(
+    eve_root: Optional[str] = None,
+    db_only_path: str = DB_ONLY_REGISTRY,
+    flag_db_only: bool = True,
+) -> DriftReport:
+    """Convenience: collect both sides and diff them. Requires load_env()."""
+    repos, missing = discover_repos(eve_root)
+    yaml_prices, collisions, unresolved = collect_yaml_prices(repos, eve_root)
+    return compute_drift(
+        yaml_prices=yaml_prices,
+        db_prices=collect_db_prices(),
+        db_only=load_db_only_registry(db_only_path),
+        checked_repos=list(repos),
+        unchecked_repos=missing,
+        collisions=collisions,
+        unresolved_parent=unresolved,
+        flag_db_only=flag_db_only,
+    )

--- a/eve/tools/elevenlabs_music/api.yaml
+++ b/eve/tools/elevenlabs_music/api.yaml
@@ -72,7 +72,7 @@ tip: |-
   - Total duration = sum of all section duration_ms values
   - For instrumental, leave `lines` as empty arrays
   - Use respect_sections_durations=True to enforce the duration_ms of each section for more precise choreography
-cost_estimate: 0.5 * duration
+cost_estimate: '0.8 * duration'
 thumbnail: app/elevenlabs58.webp
 output_type: audio
 active: true

--- a/eve/tools/fal/gpt_image_2/api.yaml
+++ b/eve/tools/fal/gpt_image_2/api.yaml
@@ -31,7 +31,7 @@ tip: |-
   - Slower than other image tools (tens of seconds at high quality) — tell the
     user it's worth the wait.
 # fal per-image: 1024x1024 low .006 / med .053 / high .211; ~2x at 4K sizes
-cost_estimate: '(quality == "high" ? 25 : quality == "medium" ? 6.5 : 1) * n_samples * (image_size == "4k" ? 1.9 : 1)'
+cost_estimate: '((quality == "high" ? 30 : quality == "medium" ? 9 : 2) * n_samples + 2 * input_images.length) * (image_size == "4k" ? 2.2 : 1)'
 output_type: image
 handler: modal
 visible: true

--- a/eve/tools/fal/vidu_reference/api.yaml
+++ b/eve/tools/fal/vidu_reference/api.yaml
@@ -26,7 +26,7 @@ tip: |-
   use seedance2_reference (but NOT with real-person references).
 # fal: ~$0.40/video flat (no duration/resolution knobs). 40 manna cost + ~25% margin.
 # VERIFY price at deploy — single pricing source.
-cost_estimate: '50'
+cost_estimate: '65'
 output_type: video
 handler: modal
 visible: true

--- a/eve/tools/google/veo3/api.yaml
+++ b/eve/tools/google/veo3/api.yaml
@@ -1,7 +1,7 @@
 name: Veo-3
 description: Generate a video including sound from a text prompt using Google Veo-3
 tip: Only use this tool if user specifically asks for Veo or requests a very high quality video or one with native audio. Note, this tool is expensive -- ask the user for confirmation before proceeding to use this tool.
-cost_estimate: 60 * duration * n_samples
+cost_estimate: '(fast ? 25 : (generate_audio ? 90 : 60)) * duration * n_samples'
 output_type: video
 visible: true
 active: true

--- a/eve/tools/hedra/api.yaml
+++ b/eve/tools/hedra/api.yaml
@@ -2,7 +2,7 @@ name: Talking Head
 description: Talking head generated with Hedra
 tip: |-
   This takes an image of a face and some speech audio and generates a talking head.
-cost_estimate: 100
+cost_estimate: '150'
 output_type: video
 handler: modal
 thumbnail: app/hedra_opt.mp4

--- a/eve/tools/thinksound/api.yaml
+++ b/eve/tools/thinksound/api.yaml
@@ -2,7 +2,7 @@ name: Add sound to video
 description: Generate audio that matches given video content + prompt using ThinkSound.
 tip: |-
   This tool synthesizes audio from video content using ThinkSound, enabling video-to-audio generation. The tool can generate various audio effects that match the video content and automatically timed correctly.
-cost_estimate: 0.5 * duration
+cost_estimate: '8'
 output_type: video
 active: true
 visible: true

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,337 @@
+"""Tests for single-source-of-truth tool pricing.
+
+These are offline: they build small YAML corpora on disk and fake database
+dictionaries, so nothing here touches Mongo.
+"""
+
+import os
+import textwrap
+
+import pytest
+
+from eve import pricing
+
+
+def write_tool(root, name, body, legacy=False):
+    """Create <root>[/legacy]/<name>/api.yaml and return its path."""
+    parts = [root, "legacy", name] if legacy else [root, name]
+    directory = os.path.join(*parts)
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, "api.yaml")
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(body))
+    return path
+
+
+# --------------------------------------------------------------------------
+# Collecting prices from the repo
+# --------------------------------------------------------------------------
+
+
+def test_collects_cost_estimate_from_yaml(tmp_path):
+    root = str(tmp_path / "tools")
+    write_tool(root, "widget", "name: Widget\ncost_estimate: 5 * n_samples\n")
+
+    prices, collisions, unresolved = pricing.collect_yaml_prices({"eve": root})
+
+    assert collisions == []
+    assert unresolved == []
+    assert prices["widget"].cost_estimate == "5 * n_samples"
+    assert prices["widget"].inherited_from is None
+
+
+def test_legacy_tools_get_the_legacy_prefix(tmp_path):
+    """The key must match get_api_files(), or `eve tool update` misses it."""
+    root = str(tmp_path / "tools")
+    write_tool(root, "controlnet", "name: CN\ncost_estimate: '10'\n", legacy=True)
+
+    prices, _, _ = pricing.collect_yaml_prices({"eve": root})
+
+    assert "legacy_controlnet" in prices
+    assert "controlnet" not in prices
+
+
+def test_price_is_inherited_from_parent_tool_within_the_repo(tmp_path):
+    """A child with no cost_estimate inherits its parent's -- from the repo.
+
+    Tool.convert_from_yaml() resolves parent_tool out of Mongo, which makes the
+    repo's answer depend on the database. Pricing must not do that.
+    """
+    root = str(tmp_path / "tools")
+    write_tool(root, "base", "name: Base\ncost_estimate: n_samples * 10\n")
+    write_tool(root, "child", "name: Child\nparent_tool: base\n")
+
+    prices, _, unresolved = pricing.collect_yaml_prices({"eve": root})
+
+    assert unresolved == []
+    assert prices["child"].cost_estimate == "n_samples * 10"
+    assert prices["child"].inherited_from == "base"
+
+
+def test_inheritance_walks_more_than_one_level(tmp_path):
+    root = str(tmp_path / "tools")
+    write_tool(root, "grand", "name: G\ncost_estimate: '7'\n")
+    write_tool(root, "mid", "name: M\nparent_tool: grand\n")
+    write_tool(root, "leaf", "name: L\nparent_tool: mid\n")
+
+    prices, _, _ = pricing.collect_yaml_prices({"eve": root})
+
+    assert prices["leaf"].cost_estimate == "7"
+
+
+def test_child_overrides_parent_price(tmp_path):
+    root = str(tmp_path / "tools")
+    write_tool(root, "base", "name: Base\ncost_estimate: '10'\n")
+    write_tool(root, "child", "name: Child\nparent_tool: base\ncost_estimate: '3'\n")
+
+    prices, _, _ = pricing.collect_yaml_prices({"eve": root})
+
+    assert prices["child"].cost_estimate == "3"
+    assert prices["child"].inherited_from is None
+
+
+def test_missing_parent_is_reported_not_silently_unpriced(tmp_path):
+    root = str(tmp_path / "tools")
+    write_tool(root, "orphan", "name: O\nparent_tool: nowhere\n")
+
+    prices, _, unresolved = pricing.collect_yaml_prices({"eve": root})
+
+    assert prices["orphan"].cost_estimate is None
+    assert unresolved and unresolved[0][0] == "orphan"
+    assert "nowhere" in unresolved[0][1]
+
+
+def test_circular_parent_chain_terminates(tmp_path):
+    root = str(tmp_path / "tools")
+    write_tool(root, "a", "name: A\nparent_tool: b\n")
+    write_tool(root, "b", "name: B\nparent_tool: a\n")
+
+    _prices, _, unresolved = pricing.collect_yaml_prices({"eve": root})
+
+    assert any("circular" in reason for _key, reason in unresolved)
+
+
+def test_duplicate_keys_only_collide_when_prices_disagree(tmp_path):
+    """Two files, one key. Harmless if they agree on price; a bug if not."""
+    agree_root = str(tmp_path / "agree")
+    write_tool(os.path.join(agree_root, "x"), "dup", "name: D\ncost_estimate: '5'\n")
+    write_tool(os.path.join(agree_root, "y"), "dup", "name: D\ncost_estimate: '5'\n")
+    _prices, collisions, _ = pricing.collect_yaml_prices({"eve": agree_root})
+    assert collisions == []
+
+    clash_root = str(tmp_path / "clash")
+    write_tool(os.path.join(clash_root, "x"), "dup", "name: D\ncost_estimate: '5'\n")
+    write_tool(os.path.join(clash_root, "y"), "dup", "name: D\ncost_estimate: '9'\n")
+    _prices, collisions, _ = pricing.collect_yaml_prices({"eve": clash_root})
+    assert collisions and collisions[0][0] == "dup"
+
+
+# --------------------------------------------------------------------------
+# The drift check
+# --------------------------------------------------------------------------
+
+
+def yaml_price(key, cost):
+    return pricing.YamlPrice(key=key, cost_estimate=cost, path=f"{key}/api.yaml", repo="eve")
+
+
+def test_no_drift_when_repo_and_db_agree():
+    report = pricing.compute_drift(
+        yaml_prices={"a": yaml_price("a", "5 * n_samples")},
+        db_prices={"a": "5 * n_samples"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert report.ok
+    assert report.drifted == []
+    assert report.compared == 1
+
+
+def test_drift_is_detected_and_reported_both_ways():
+    """This is the check that would have caught the 17 drifted tools."""
+    report = pricing.compute_drift(
+        yaml_prices={"a": yaml_price("a", "2 * n_samples")},
+        db_prices={"a": "5 * n_samples"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert not report.ok
+    assert report.drifted == [("a", "2 * n_samples", "5 * n_samples")]
+    text = pricing.format_report(report, "eden-prod")
+    assert "PRICE DRIFT" in text
+    assert "2 * n_samples" in text and "5 * n_samples" in text
+
+
+def test_whitespace_is_not_a_price_change():
+    report = pricing.compute_drift(
+        yaml_prices={"a": yaml_price("a", "5  *   n_samples")},
+        db_prices={"a": "5 * n_samples"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert report.ok
+
+
+def test_a_yaml_tool_missing_a_price_drifts_against_a_priced_db_tool():
+    """The five-tools-become-free scenario, seen from the checker's side."""
+    report = pricing.compute_drift(
+        yaml_prices={"a": yaml_price("a", None)},
+        db_prices={"a": "n_samples * 10"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert not report.ok
+    assert report.drifted == [("a", None, "n_samples * 10")]
+
+
+def test_new_tool_in_repo_is_informational_not_a_failure():
+    report = pricing.compute_drift(
+        yaml_prices={"brand_new": yaml_price("brand_new", "1")},
+        db_prices={},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert report.ok
+    assert report.not_yet_in_db == ["brand_new"]
+
+
+def test_registered_db_only_tool_passes_but_unregistered_one_fails():
+    report = pricing.compute_drift(
+        yaml_prices={},
+        db_prices={"retired": "5", "mystery": "9"},
+        db_only=["retired"],
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert not report.ok
+    assert report.registered_db_only == ["retired"]
+    assert report.unregistered_db_only == [("mystery", "9")]
+
+
+def test_db_only_tools_are_not_flagged_when_flag_db_only_is_off():
+    """STAGE legitimately carries tools that were never meant to reach a repo."""
+    report = pricing.compute_drift(
+        yaml_prices={},
+        db_prices={"experiment": "0"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+        flag_db_only=False,
+    )
+    assert report.ok
+    assert report.db_only_untracked_info == ["experiment"]
+
+
+def test_missing_repo_never_makes_its_tools_look_deleted():
+    """The three-repo rule: an unchecked repo must not imply deletion."""
+    report = pricing.compute_drift(
+        yaml_prices={},
+        db_prices={"lives_in_private_workflows": "20"},
+        db_only=[],
+        checked_repos=["eve", "workflows"],
+        unchecked_repos=["private_workflows"],
+    )
+    assert report.ok
+    assert report.unregistered_db_only == []
+    assert "UNCHECKED" in pricing.format_report(report, "eden-prod")
+
+
+def test_collisions_and_unresolved_parents_fail_the_check():
+    assert not pricing.compute_drift(
+        yaml_prices={}, db_prices={}, collisions=[("d", "a.yaml", "b.yaml")]
+    ).ok
+    assert not pricing.compute_drift(
+        yaml_prices={}, db_prices={}, unresolved_parent=[("o", "missing parent")]
+    ).ok
+
+
+# --------------------------------------------------------------------------
+# Expression validation -- a syntax error must never reach production
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "6 + 4 * n_samples * (width / 1024)",
+        "50",
+        "0.8 * duration",
+        'output == "video" ? 85 * duration : 13 * n_samples',
+        "5.5 + 0.05 * image_input.length",
+        '20 * sumLengths(segments, "text")',
+        "high_quality ? 12 * n_samples : 6 * n_samples",
+        '(quality == "high" ? 30 : quality == "medium" ? 9 : 2) * n_samples',
+        "1.0 * n_frames * (width + height)/(2*512) * (steps/25)",
+    ],
+)
+def test_real_cost_expressions_validate(expression):
+    assert pricing.validate_expression(expression) is None
+
+
+@pytest.mark.parametrize(
+    "expression",
+    ["5 * * n_samples", "(5 * n_samples", "5 +", '"just a string"'],
+)
+def test_broken_cost_expressions_are_rejected(expression):
+    assert pricing.validate_expression(expression) is not None
+
+
+def test_invalid_expression_fails_the_drift_check():
+    report = pricing.compute_drift(
+        yaml_prices={"a": yaml_price("a", "5 * * n_samples")},
+        db_prices={"a": "5 * * n_samples"},
+        checked_repos=["eve", "workflows", "private_workflows"],
+    )
+    assert not report.ok
+    assert report.invalid and report.invalid[0][0] == "a"
+    assert "INVALID COST EXPRESSIONS" in pricing.format_report(report, "eden-prod")
+
+
+def test_validate_expression_ignores_missing_arguments():
+    """Validation must not need real args, or it flags healthy tools."""
+    assert pricing.validate_expression("n_samples * width / height") is None
+
+
+# --------------------------------------------------------------------------
+# The guard that stops a live price being erased
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "old,new,should_block",
+    [
+        ("n_samples * 10", None, True),      # yaml lost its cost_estimate
+        ("n_samples * 10", "", True),        # blank
+        ("n_samples * 10", "0", True),       # zeroed -> tool becomes free
+        ("n_samples * 10", "0.0", True),
+        ("n_samples * 10", "n_samples * 5", False),  # a real, intentional change
+        (None, "5", False),                  # newly priced tool
+        ("0", "0", False),                   # deliberately free tool stays free
+        (None, None, False),
+    ],
+)
+def test_price_erasure_guard(old, new, should_block):
+    """Refuse to write an absent/zero price over a live one.
+
+    This single rule is what turns "five tools are now free" into an error.
+    """
+    assert pricing.would_erase_price(old, new) is should_block
+
+
+def test_normalize_treats_none_and_values_distinctly():
+    assert pricing.normalize(None) is None
+    assert pricing.normalize("  5 *  n ") == "5 * n"
+    assert pricing.normalize(50) == "50"
+
+
+# --------------------------------------------------------------------------
+# The shipped db-only registry must describe the real world
+# --------------------------------------------------------------------------
+
+
+def test_db_only_registry_loads_and_is_a_list_of_names():
+    keys = pricing.load_db_only_registry()
+    assert isinstance(keys, list)
+    assert keys, "registry should not be empty"
+    assert all(isinstance(k, str) and k for k in keys)
+    assert len(keys) == len(set(keys)), "registry has duplicates"
+
+
+def test_repo_roots_match_get_api_files_layout():
+    from eve.tool import get_api_files  # noqa: F401  (import proves it exists)
+
+    roots = pricing.repo_roots()
+    assert set(roots) == {"eve", "workflows", "private_workflows"}
+    assert roots["eve"].endswith(os.path.join("eve", "tools"))


### PR DESCRIPTION
## The problem

A tool's price lives in two places: the `cost_estimate` string in its `api.yaml`, and the `tools3` document in Mongo that production actually reads. Nothing kept them in step. `eve tool update` was the only bridge, it was manual, and it overwrote whole documents with no preview of what would change.

Measured on 2026-08-21: **17 tools had a repo price that disagreed with what users were actually being charged.** Running `eve tool update` with no arguments would have *cut* live prices.

**The fix: the repo is the source of truth, the database is a projection of it, and CI proves they agree on every PR.**

## Why this shape

The obvious design — "repo is truth, sync on deploy, fail CI on drift" — is right, but three properties of the real system make the naive version wrong, and all three were found by reading the actual code and querying live Mongo:

1. **Prices are inherited, through the database.** A tool with `parent_tool` and no `cost_estimate` uses its parent's. `Tool.convert_from_yaml` resolves that parent via `_get_schema(parent, from_yaml=False)` — a **Mongo read**. So "what the repo says" is not a function of the repo: it depends on the database, and on the order tools happen to be written during a bulk update. `eve/pricing.py` resolves inheritance **inside the YAML corpus only**, so the repo's answer is deterministic.

2. **The repo is not authoritative about deletion.** 22 tools exist in `tools3` with no `api.yaml` anywhere (retired ComfyUI workflows, tools whose source is gone). Sync is therefore **upsert-only, never delete**. But that would leave a hole — anyone could hand-edit Mongo and never be noticed — so the accepted database-only keys are enumerated in `eve/db_only_tools.yaml`, and an *unlisted* database-only tool **fails the check**.

3. **Tools live in three repos**, and CI does not always have all of them. `private_workflows` exists (verified: 4 tools). A repo that is not checked out is reported **UNCHECKED**; its tools are never treated as deleted, drifted, or unpriced. `pricing-check.yaml` checks out `private_workflows` only if a `PRIVATE_WORKFLOWS_PAT` secret is configured, and degrades cleanly when it is not.

## What changed

**One place to edit.** To change a price: edit `cost_estimate` in the tool's `api.yaml` and merge. That is the whole workflow.

**One command to ask.**
```
$ eve tool price flux_dev            # or: make price TOOL=flux_dev
flux_dev
  live on PROD: '7 * n_samples * ( speed_quality_tradeoff * 3 + ...)'
  in repo    : '7 * n_samples * ( speed_quality_tradeoff * 3 + ...)'
  defined in : workflows/workspaces/fast/workflows/flux_dev/api.yaml
  AGREES
  test args  : {...}
  -> 7 manna ($0.07)
```
It reports which file the number really came from, including when it was inherited from a parent.

**A gate that runs on every PR.** `eve tool price-check` compares every effective `cost_estimate` against `tools3` and fails with a readable diff. This is the check that would have caught all 17 drifted tools. **PROD is blocking; STAGE is advisory** — see below.

**The dangerous command is now safe.**
- `eve tool update` with no `names` prints the price diff it is about to apply and requires confirmation. `--yes` opts out for CI.
- It **refuses to write an absent or zeroed `cost_estimate` over a live one** (`pricing.would_erase_price`). That single guard is what turns "five tools are now free" into an error. `--allow-price-removal` is the deliberate override.
- A name matching no `api.yaml` is now an error instead of a **silent no-op** — the old behaviour filtered to an empty set and reported success.

**Two real bugs found and fixed on the way:**
- `update-tools.yaml` derived a tool name as the folder basename, but `get_api_files()` prefixes anything under `legacy/` with `legacy_`. So **every CI sync of a legacy tool updated nothing and reported success.** Fixed.
- The sync was fire-and-forget; it now verifies afterwards that no drift remains.

**The drift check immediately earned its keep:** it found **6 more tools** (`elevenlabs_music`, `hedra`, `thinksound`, `veo3`, `vidu_reference`, `gpt_image_2`) that the hand-written sync pass in #577 missed. The first commit here aligns them, copying the value straight from the live PROD document.

## Questions asked in review

**Tools that exist only in the DB** — 22 of them; enumerated in `eve/db_only_tools.yaml`. Sync never deletes. An unlisted one fails the check.

**Should `Tool.save()` overwrite whole documents?** It shouldn't, but narrowing it is a much larger change than pricing — `tools3` documents carry runtime state (`order`, and whatever the frontend writes) that a whole-document write from YAML clobbers. **Deliberately left alone.** The guard + confirmation + drift check make the blast radius visible instead of silent, which is the part that was actually hurting.

**Should `cost_estimate` be validated at PR time?** Yes, now it is. Every expression is evaluated against a probe environment that satisfies arithmetic, `.length`, indexing and `sumLengths`, so a syntax error fails the PR rather than surfacing as a failed generation in production. Validation deliberately does not need real arguments.

**Should STAGE and PROD ever differ?** Yes, and they do — `eden-stg` legitimately carries in-development tools (`artifact_*`, `eden_mcp`, `weather_mcp`, `verdelis_story`) and experimental prices that were never meant to reach a repo. So **PROD is the required check** (it is where money moves) and **STAGE is advisory**, and the database-only guard is PROD-only.

## Verification

Checked against live `eden-prod` with all three repos present — **184 tools compared, zero drift, zero invalid expressions** (with #577 and workflows#50 applied).

```
$ pytest tests/ -q -m "not live and not integration"
116 passed, 32 deselected, 484 warnings in 5.08s
```

43 of those are new, covering inheritance resolution, the `legacy_` key rule, missing/circular parents, drift detection both directions, the unchecked-repo rule, the DB-only registry, expression validation against 9 real production expressions, and the price-erasure guard.

**No live price is changed by this PR.**

## Deliberately not included

- **The `workflows` repo has no CI at all**, so a price edited there is still not auto-synced. This PR's gate *detects* such drift (eve's CI checks out `workflows`), but the changed-files sync equivalent belongs in that repo — a follow-up PR there.
- **`Tool.convert_from_yaml` derives a different key than `get_api_files()`** for tools with a `parent_tool`: `legacy/controlnet/api.yaml` is addressed as `legacy_controlnet` but *stored* as `controlnet`. That is how both spellings came to exist in `tools3`. `eve tool update` now warns when the stored key differs from the name you asked for, but reconciling the duplicate documents is a separate migration.
- `beeple_ai` is defined twice in `private_workflows` (`beeple_ai/` and `beeple_ai_old/`), one silently shadowing the other. Currently harmless — the prices agree — and the checker fails if they ever stop agreeing.

## Note on the base branch

Stacked on `chore/sync-tool-prices-to-db` (#577) so the diff shows only this work. GitHub retargets it to `staging` automatically when #577 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
