### PR TITLE
fix(discord): stop requesting the privileged GUILD_MEMBERS intent

### DIFF
--- a/eve/agent/deployments/gateway_v3.py
+++ b/eve/agent/deployments/gateway_v3.py
@@ -1314,7 +1314,10 @@ intents.messages = True
 intents.guilds = True
 intents.reactions = True
 intents.dm_messages = True
-intents.members = True
+# NOTE: members (GUILD_MEMBERS) is deliberately NOT requested. It is a privileged
+# intent we never consume -- no on_member_* handlers, no guild.members/get_member/
+# fetch_members/chunk. guild.fetch_member() is a REST call and works without it.
+# Requesting an intent the app is not approved for closes the gateway with 4014.
 
 bot = discord.Bot(intents=intents)
 _commands_synced = False


### PR DESCRIPTION
## Why

Discord's privileged intent review (deadline **2026-11-11**) applies to the Eden, Abraham and EdenDev apps. We are applying for **MESSAGE_CONTENT only**.

Once the grant is narrowed, continuing to request `GUILD_MEMBERS` closes the gateway with **4014 / `PrivilegedIntentsRequired`** and the bot fails to start entirely — not a graceful degradation. This drops the request ahead of the grant change.

## Why GUILD_MEMBERS is safe to drop

Nothing consumes it:

- no `on_member_join` / `on_member_remove` / `on_member_update` handlers
- no `guild.members` / `get_member()` / `fetch_members()` / `chunk()` call sites
- no use of the intent-gated bulk `GET /guilds/{id}/members` endpoint
- `guild.fetch_member()` (`gateway_v3.py:1849`) is a single-member REST call, not intent-gated
- `member_count` in the channels API reads a Mongo `DiscordGuild` doc, refreshed via REST `approximate_member_count`

`presences` was already never requested — `Intents.default()` leaves it off and nothing set it.

## Verification

Live test against the staging bot with the exact new intent set:

```
connecting with intents.value=53608189 members=False
READY as Eden (STAGING)#8589 in 1 guild(s) -- no 4014
   fetch_member OK in 'Eden': Eden (STAGING), joined 2026-01-03
   guild.member_count=2670  cached members=1
```

Bitmask delta is exactly 2 (`GUILD_MEMBERS`, 1<<1); `message_content` and all message-delivery intents unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)