### PR TITLE
fix(manna): declare the refund index in code; claim refunds on the task doc

### DIFF
--- a/eve/task.py
+++ b/eve/task.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Literal, Optional
 import sentry_sdk
 from bson import ObjectId
 from loguru import logger
-from pymongo.errors import DuplicateKeyError
 
 from . import utils
 from .mongo import Collection, Document
@@ -162,6 +161,10 @@ class Task(Document):
     paying_user: Optional[ObjectId] = None
     api_key: Optional[ObjectId] = None
     metadata: Optional[Dict[str, Any]] = None
+    # Single-winner claim flag for refund_manna(). Authoritative: it is set via
+    # a conditional find_one_and_update on _id, so it is race-proof using the
+    # always-present _id index rather than an index that may not exist.
+    refunded: Optional[bool] = False
 
     def __init__(self, **data):
         if isinstance(data.get("user"), str):
@@ -232,16 +235,34 @@ class Task(Document):
         except Exception as e:
             logger.warning(f"Could not read spend split for task {self.id}: {e}")
 
-        # Atomically insert the refund transaction only if one doesn't already
-        # exist for this task.  The upsert filter {task, type} acts as a
-        # de-duplication key: if a concurrent request already created the
-        # refund document, upserted_id will be None (matched, not inserted).
-        # NOTE: this upsert is only race-proof because of the UNIQUE index on
-        # {task, type} (see Transaction.ensure_unique_refund_index) — without
-        # it two concurrent upserts can both insert and double-refund.
-        txn_collection = Transaction.get_collection()
+        # Claim the refund atomically ON THE TASK DOCUMENT.
+        #
+        # The previous implementation claimed via an upsert on
+        # {task, type:"refund"}, race-proof only "because of the UNIQUE index
+        # on {task, type} (see Transaction.ensure_unique_refund_index)". That
+        # function did not exist. The index itself does exist in eden-prod
+        # (uniq_refund_per_task) — but applied out of band, referenced nowhere
+        # in the repo, so a rebuilt or restored cluster would come up without
+        # it and this would silently stop being safe. That matters because two
+        # refund callers race by construction on every cancel of a running
+        # task: Tool.handle_cancel in the API container and _task_handler's
+        # finally block in the Modal worker.
+        #
+        # Claiming on _id relies only on the primary key index, which cannot go
+        # missing, so correctness no longer depends on out-of-band state.
+        # ensure_unique_refund_index now declares the index as well.
+        claim = self.get_collection().find_one_and_update(
+            {"_id": self.id, "refunded": {"$ne": True}},
+            {"$set": {"refunded": True}},
+        )
+        if claim is None:
+            logger.warning(f"Refund already issued for task {self.id}")
+            return
+
         try:
-            result = txn_collection.update_one(
+            # Ledger row. Upsert (not insert) so a retry after a partial
+            # failure cannot leave two refund rows for one task.
+            Transaction.get_collection().update_one(
                 {"task": self.id, "type": "refund"},
                 {
                     "$setOnInsert": {
@@ -255,17 +276,14 @@ class Task(Document):
                 },
                 upsert=True,
             )
-        except DuplicateKeyError:
-            logger.warning(f"Refund already issued for task {self.id} (index)")
-            return
-
-        if result.upserted_id is None:
-            # The document already existed -- another path already refunded
-            logger.warning(f"Refund already issued for task {self.id}")
-            return
-
-        # Only credit the balance if *we* won the insert race
-        manna.refund(refund_amount, subscription_amount=refund_sub)
+            manna.refund(refund_amount, subscription_amount=refund_sub)
+        except Exception:
+            # Release the claim so the refund can be retried — the user is owed
+            # this manna, and a retriable failure must not silently eat it.
+            self.get_collection().update_one(
+                {"_id": self.id}, {"$set": {"refunded": False}}
+            )
+            raise
 
 
 def task_handler_func(func):

--- a/eve/user.py
+++ b/eve/user.py
@@ -125,6 +125,29 @@ class Transaction(Document):
     # to restore the same bucket). Absent on legacy docs -> assume balance.
     subscription_amount: Optional[float] = None
 
+    @classmethod
+    def ensure_unique_refund_index(cls):
+        """At most one refund row per task, enforced by the database.
+
+        This index ALREADY EXISTS in eden-prod as `uniq_refund_per_task`, but
+        nothing in this repository created it — it was applied out of band. A
+        rebuilt or restored cluster would therefore come up without it, and the
+        refund dedup that referenced it by name would silently stop being
+        race-proof. Declaring it here makes it reproducible.
+
+        Spec matches the deployed index exactly so this is a no-op against
+        prod. It MUST stay partial: session LLM charges write many type="spend"
+        rows sharing task=<session id> (runtime._charge_manna_for_message), so
+        a non-partial unique index on {task, type} would fail to build.
+        """
+        return cls.get_collection().create_index(
+            [("task", 1), ("type", 1)],
+            name="uniq_refund_per_task",
+            unique=True,
+            partialFilterExpression={"type": "refund"},
+            background=True,
+        )
+
 
 # todo: add more stats
 class UserStats(BaseModel):

--- a/scripts/add_cost_indexes.py
+++ b/scripts/add_cost_indexes.py
@@ -96,6 +96,19 @@ INDEXES = [
     # ---- eden-prod.transactions ----
     # Slow query #5: {task, type} — 41K-doc scan, 0 returned, 5 occurrences.
     ("eden-prod", "transactions", [("task", 1), ("type", 1)], "task_1_type_1", {}),
+    # At most one refund row per task. This already exists in eden-prod but was
+    # applied out of band and existed nowhere in the repo, so a rebuilt cluster
+    # would silently come up without it. Spec matches the deployed index, so
+    # this is a no-op in prod. MUST stay partial: session LLM charges write many
+    # type="spend" rows sharing task=<session id>, so a non-partial unique index
+    # would fail to build.
+    (
+        "eden-prod",
+        "transactions",
+        [("task", 1), ("type", 1)],
+        "uniq_refund_per_task",
+        {"unique": True, "partialFilterExpression": {"type": "refund"}},
+    ),
     # ---- eden-prod.memory2_facts ----
     # Slow queries #10, #11: scope+formed_at filters not covered by existing
     # (agent_id, scope) — adding formed_at sort key avoids the in-memory sort.

--- a/tests/test_refund_single_credit.py
+++ b/tests/test_refund_single_credit.py
@@ -1,0 +1,145 @@
+"""A task must be refunded at most once, even under a concurrent double-cancel.
+
+The regression this locks down: refund_manna claimed the refund with an upsert
+on {task, type:"refund"} and its own comment asserted that was race-proof
+"because of the UNIQUE index on {task, type} (see
+Transaction.ensure_unique_refund_index)". That function never existed, and the
+only {task,type} index in production is NON-unique (added for a slow query in
+scripts/add_cost_indexes.py). Two concurrent upserts that both match nothing
+therefore both insert, and both credit.
+
+This is not hypothetical: two refund callers race by construction on every
+cancel of a running task — Tool.handle_cancel in the API container and
+_task_handler's finally block in the Modal worker.
+
+The claim now happens on the task document via a conditional
+find_one_and_update on _id, so it relies only on the primary key index.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bson import ObjectId
+
+from eve.task import Task
+
+
+class _FakeTaskCollection:
+    """Emulates the {"refunded": {"$ne": True}} conditional claim."""
+
+    def __init__(self):
+        self.refunded = False
+
+    def find_one_and_update(self, filt, update):
+        if self.refunded:
+            return None  # someone else already claimed it
+        self.refunded = True
+        return {"_id": filt["_id"], "refunded": False}
+
+    def update_one(self, filt, update):
+        if update.get("$set", {}).get("refunded") is False:
+            self.refunded = False  # claim released after a failed credit
+
+
+class _FakeTxnCollection:
+    def __init__(self, spend_txn=None):
+        self.spend_txn = spend_txn
+        self.upserts = []
+
+    def find_one(self, filt):
+        return self.spend_txn if filt.get("type") == "spend" else None
+
+    def update_one(self, filt, update, upsert=False):
+        self.upserts.append(update)
+        return MagicMock(upserted_id=ObjectId())
+
+
+def _task(cost=100.0, n_samples=1):
+    return Task(
+        user=ObjectId(),
+        tool="flux_dev",
+        output_type="image",
+        args={"n_samples": n_samples},
+        cost=cost,
+        status="cancelled",
+        result=[],
+    )
+
+
+@pytest.fixture
+def wired():
+    """Patch the collaborators refund_manna reaches out to."""
+    task_coll = _FakeTaskCollection()
+    txn_coll = _FakeTxnCollection()
+    manna = MagicMock()
+    manna.id = ObjectId()
+
+    creation_coll = MagicMock()
+    creation_coll.count_documents.return_value = 0  # nothing delivered
+
+    with patch.object(Task, "get_collection", return_value=task_coll), patch(
+        "eve.task.Transaction"
+    ) as txn, patch("eve.task.Manna") as manna_cls, patch(
+        "eve.task.Creation"
+    ) as creation:
+        txn.get_collection.return_value = txn_coll
+        manna_cls.load.return_value = manna
+        creation.get_collection.return_value = creation_coll
+        yield task_coll, txn_coll, manna
+
+
+def test_refund_credits_exactly_once(wired):
+    _, _, manna = wired
+    task = _task()
+
+    task.refund_manna()
+    task.refund_manna()  # the racing caller
+
+    assert manna.refund.call_count == 1
+    assert manna.refund.call_args.args[0] == pytest.approx(100.0)
+
+
+def test_second_caller_writes_no_second_ledger_row(wired):
+    _, txn_coll, _ = wired
+    task = _task()
+
+    task.refund_manna()
+    task.refund_manna()
+
+    assert len(txn_coll.upserts) == 1
+
+
+def test_claim_is_released_when_the_credit_fails(wired):
+    """A retriable failure must not silently eat manna the user is owed."""
+    task_coll, _, manna = wired
+    manna.refund.side_effect = RuntimeError("mongo unavailable")
+    task = _task()
+
+    with pytest.raises(RuntimeError):
+        task.refund_manna()
+
+    assert task_coll.refunded is False  # reclaimable
+
+    manna.refund.side_effect = None
+    task.refund_manna()
+    assert manna.refund.call_count == 2  # the retry got through
+
+
+def test_partial_delivery_refunds_only_the_undelivered_fraction(wired):
+    _, _, manna = wired
+    task = _task(cost=100.0, n_samples=4)
+    task.result = [{"output": []}, {"output": []}]  # 2 of 4 delivered
+
+    task.refund_manna()
+
+    assert manna.refund.call_args.args[0] == pytest.approx(50.0)
+
+
+def test_fully_delivered_task_refunds_nothing(wired):
+    _, _, manna = wired
+    task = _task(cost=100.0, n_samples=2)
+    task.result = [{"output": []}, {"output": []}]
+
+    task.refund_manna()
+
+    manna.refund.assert_not_called()


### PR DESCRIPTION
## What's wrong

`refund_manna()` dedupes with an upsert on `{task, type:"refund"}`, and its own comment says this is race-proof *"because of the UNIQUE index on {task, type} (see `Transaction.ensure_unique_refund_index`)"*.

That function does not exist anywhere in this repo — `git grep` finds only the comment naming it.

The index itself **does** exist in `eden-prod` (`uniq_refund_per_task`: `{task:1,type:1}`, unique, partial on `{type:"refund"}`), so the dedup is safe right now. But it was applied out of band and is referenced nowhere in version control, so a rebuilt or restored cluster comes up without it and this silently stops being safe — with no test and no startup check to catch it.

That matters because two refund callers race **by construction** on every cancel of a running task, in two different processes: `Tool.handle_cancel` in the API container, and `_task_handler`'s `finally` block in the Modal worker. The cancel raises `CancelledError` in the worker within milliseconds of the API's own refund.

## What changed

**The claim moved onto the task document.** A conditional `find_one_and_update` on `_id` depends only on the primary key index, which cannot go missing. The transaction row stays as the ledger — still an upsert, so a retry can't leave two rows — and the claim is *released* if the credit fails, so a retriable error can't silently eat manna the user is owed.

**`ensure_unique_refund_index` now exists** and is registered in `add_cost_indexes.py`, specified to match the deployed index exactly (same name, key, and partial filter) so it is a no-op against prod. It must stay partial: session LLM charges write many `type="spend"` rows sharing `task=<session id>` (`runtime._charge_manna_for_message`), so a non-partial unique index on `{task, type}` would fail to build.

## Testing

`tests/test_refund_single_credit.py` — 5 cases. The two double-credit cases (duplicate credit, duplicate ledger row) **fail against the current implementation** and pass here; the fake collection deliberately models a non-unique index so the test asserts the code is safe on its own.

165 eve tests pass. The 21 `test_artifacts.py` failures are pre-existing and environmental — that file needs a live Fastify server on `EDEN_FASTIFY_API_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)