### PR TITLE
fix(billing): stop a run once its cost-plus top-up can no longer be collected

### DIFF
--- a/eve/agent/session/runtime.py
+++ b/eve/agent/session/runtime.py
@@ -247,6 +247,9 @@ class PromptSessionRuntime:
             self._run_floor_charged = 0.0
             self._run_cost_usd = 0.0
             self._run_topups_charged = 0.0
+            # Set when a cost-plus top-up fails (almost always insufficient
+            # manna). Enforced at the next turn boundary; see below.
+            self._billing_failed_error = None
             while not prompt_session_finished:
                 turn_count += 1
                 if turn_count > max_turns:
@@ -277,6 +280,37 @@ class PromptSessionRuntime:
                             session_run_id=self.session_run_id,
                         )
                         return
+
+                # Stop the run if a previous turn's top-up could not be
+                # collected.
+                #
+                # The 2-manna floor is charged once per RUN, so it stops
+                # asserting the balance after the first turn. Cost-plus top-ups
+                # are deliberately best-effort — a post-hoc charge failure must
+                # not kill a response the user already received — but until
+                # this check existed, that failure was only logged, and the
+                # tool loop kept issuing paid LLM calls up to
+                # MAX_PROMPT_SESSION_TURNS. An account funded with 2 manna
+                # could therefore buy a 25-turn loop: the floor drains the
+                # balance on turn 1 and every later top-up raises and is
+                # swallowed. Enforcing at the turn boundary keeps the
+                # already-delivered response intact and bills the next one.
+                if os.environ.get("FF_MANNA_BILLING") and getattr(
+                    self, "_billing_failed_error", None
+                ):
+                    billing_error_message = self._persist_billing_error_message(
+                        self._billing_failed_error
+                    )
+                    yield SessionUpdate(
+                        type=UpdateType.ASSISTANT_MESSAGE,
+                        message=billing_error_message,
+                        session_run_id=self.session_run_id,
+                    )
+                    yield SessionUpdate(
+                        type=UpdateType.END_PROMPT,
+                        session_run_id=self.session_run_id,
+                    )
+                    return
 
                 # Always attempt billing once rate limits are cleared (or disabled).
                 # The flat floor is a per-turn reservation: charge it on the
@@ -896,7 +930,14 @@ class PromptSessionRuntime:
                         )
             except Exception as e:
                 # Post-hoc charge failure must not kill a response the user
-                # already received; the balance floor is enforced pre-turn.
+                # already received — but it must stop the NEXT turn, or the
+                # tool loop keeps making paid LLM calls that can no longer be
+                # billed. Recorded here, enforced at the turn boundary.
+                self._billing_failed_error = (
+                    e
+                    if isinstance(e, APIError)
+                    else APIError(f"Insufficient manna: {e}", status_code=402)
+                )
                 logger.warning(f"Cost-plus manna charge failed: {e}")
 
         # Increment message count for the agent (sender)

--- a/tests/test_llm_billing_stops_run.py
+++ b/tests/test_llm_billing_stops_run.py
@@ -1,0 +1,123 @@
+"""A run whose cost-plus top-up cannot be collected must stop taking turns.
+
+The regression this locks down: the 2-manna floor is charged once per RUN, so
+after turn 1 nothing re-asserts the balance. Cost-plus top-ups are deliberately
+best-effort — a post-hoc charge must not kill a response the user already
+received — but the failure was previously only logged. An account funded with 2
+manna therefore bought a full MAX_PROMPT_SESSION_TURNS tool loop: the floor
+drains the balance on turn 1, and every later top-up raises and is swallowed.
+
+The failure is now recorded and enforced at the next turn boundary, which keeps
+the already-delivered response intact while refusing to start another turn.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from eve.agent.session.models import ChatMessage
+from eve.agent.session.runtime import PromptSessionRuntime
+from eve.api.errors import APIError
+
+MAX_TURNS = 5
+
+
+def _runtime(fail_billing_on_turn=None):
+    """A runtime carrying only the attributes _prompt_loop touches."""
+    r = object.__new__(PromptSessionRuntime)
+    r.instrumentation = None
+    r.session_run_id = "run-1"
+    r.billing_user_id = None
+    r.billing_user_doc = None
+    r.billed_user_doc = None
+    r.rate_limiter = None
+    r.stream = False
+    r.llm_context = MagicMock()
+    r.session = MagicMock()
+    r.context = None
+    r.active_platform = None
+    r.social_post_used = False
+    r.social_reprompt_attempted = False
+
+    actor = MagicMock()
+    actor.id = "agent-1"
+    actor.username = "agent"
+    actor.name = "Agent"
+    actor.userImage = None
+    r.actor = actor
+
+    r._register_active_request = MagicMock()
+    r._start_update = MagicMock(return_value="START")
+    r._ensure_not_cancelled = MagicMock()
+    r._refresh_llm_messages = AsyncMock()
+    r._maybe_disable_tools = MagicMock()
+    r._charge_manna_for_message = MagicMock()
+    r._persist_billing_error_message = MagicMock(
+        return_value=ChatMessage(role="eden", content="insufficient manna")
+    )
+    r._select_provider = MagicMock(return_value="provider")
+    # "tool_use" keeps the loop going, so it runs until max_turns or the guard.
+    r._non_stream_llm_response = AsyncMock(return_value={"stop_reason": "tool_use"})
+    r._maybe_notify_user = AsyncMock()
+
+    async def _no_tool_updates(_message):
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    r._process_tool_calls = _no_tool_updates
+
+    turns = {"n": 0}
+
+    async def _persist(_llm_result):
+        turns["n"] += 1
+        if fail_billing_on_turn is not None and turns["n"] == fail_billing_on_turn:
+            # What the cost-plus except block now records.
+            r._billing_failed_error = APIError(
+                "Insufficient manna", status_code=402
+            )
+        return ChatMessage(role="assistant", content="ok")
+
+    r._persist_assistant_message = _persist
+    return r
+
+
+async def _drain(runtime):
+    return [u async for u in runtime._prompt_loop()]
+
+
+@pytest.mark.asyncio
+async def test_failed_topup_stops_the_run_after_the_current_turn(monkeypatch):
+    monkeypatch.setenv("FF_MANNA_BILLING", "1")
+    monkeypatch.setenv("MAX_PROMPT_SESSION_TURNS", str(MAX_TURNS))
+    runtime = _runtime(fail_billing_on_turn=1)
+
+    await _drain(runtime)
+
+    # Turn 1 completed and was delivered; turn 2 never reached the LLM.
+    assert runtime._select_provider.call_count == 1
+    runtime._persist_billing_error_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_run_keeps_taking_turns(monkeypatch):
+    """The guard must not fire when every top-up succeeded."""
+    monkeypatch.setenv("FF_MANNA_BILLING", "1")
+    monkeypatch.setenv("MAX_PROMPT_SESSION_TURNS", str(MAX_TURNS))
+    runtime = _runtime(fail_billing_on_turn=None)
+
+    await _drain(runtime)
+
+    assert runtime._select_provider.call_count == MAX_TURNS
+    runtime._persist_billing_error_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_guard_is_inert_when_manna_billing_is_disabled(monkeypatch):
+    monkeypatch.delenv("FF_MANNA_BILLING", raising=False)
+    monkeypatch.setenv("MAX_PROMPT_SESSION_TURNS", str(MAX_TURNS))
+    runtime = _runtime(fail_billing_on_turn=1)
+
+    await _drain(runtime)
+
+    assert runtime._select_provider.call_count == MAX_TURNS
+    runtime._persist_billing_error_message.assert_not_called()


### PR DESCRIPTION
## What's wrong

The 2-manna floor is charged **once per run** (`_run_floor_charged`), so after the first turn nothing re-asserts the caller's balance. Cost-plus top-ups in `_persist_assistant_message` are deliberately best-effort — a post-hoc charge failure must not kill a response the user already received — but the failure was only logged and the loop carried on:

```python
except Exception as e:
    # Post-hoc charge failure must not kill a response the user
    # already received; the balance floor is enforced pre-turn.
    logger.warning(f"Cost-plus manna charge failed: {e}")
```

That comment's premise no longer holds — the floor stops enforcing after turn 1.

An account funded with ~2 manna therefore buys a full `MAX_PROMPT_SESSION_TURNS` (25) tool loop: the floor drains the balance on turn 1, every later top-up raises on insufficient manna and is swallowed, and tool calls that fail their own `check_manna` return *error results* — which is exactly what keeps the LLM looping. On a large context that's several dollars of provider spend against 2 manna collected.

This is a **regression from the streaming billing fix (#572)**, which moved the floor from per-LLM-call to once-per-run. Before it, an unfunded account hit the pre-turn `APIError` path and the run ended.

## The fix

Record the failure on the runtime and enforce it at the next turn boundary. That keeps the already-delivered response intact — the property the best-effort design exists to protect — while refusing to start another paid turn.

## Testing

`tests/test_llm_billing_stops_run.py` drives the real `_prompt_loop` generator with the collaborators stubbed.

- The stop case **fails against the current implementation** — the run continues to `max_turns` instead of ending after turn 1.
- Two control cases assert the guard does *not* fire on a healthy run, and is inert when `FF_MANNA_BILLING` is unset. Premature termination is the real hazard with a change like this, so both directions are covered.

Full suite green: 168 passed. (The `test_artifacts.py` failures are pre-existing and environmental — that file needs a live Fastify server on `EDEN_FASTIFY_API_URL`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)